### PR TITLE
feat: add socket mode for delegating token retrieval to a ghtkn daemon

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "^(Edit|Write|MultiEdit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "go vet ./... && go test -race -covermode=atomic ./... && golangci-lint fmt && golangci-lint run"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/ghtkn/client.go
+++ b/ghtkn/client.go
@@ -3,6 +3,9 @@
 package ghtkn
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 
@@ -12,12 +15,8 @@ import (
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/keyring"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/log"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/socket"
 )
-
-// New creates a new Client instance with the provided input configuration.
-func New() *Client {
-	return api.New(api.NewInput())
-}
 
 type (
 	AccessToken        = keyring.AccessToken
@@ -30,8 +29,89 @@ type (
 	DefaultBrowser     = browser.Browser
 	ClientIDReader     = api.PasswordReader
 	InputGet           = api.InputGet
-	Client             = api.TokenManager
 )
+
+// Client retrieves GitHub App access tokens. It runs in one of two modes:
+//
+//   - keyring mode (default): tokens are obtained via the OAuth device flow
+//     and cached in the system keyring.
+//   - socket mode: token retrieval is delegated to a ghtkn daemon over a Unix
+//     socket. Activated when the GHTKN_SOCK environment variable is set.
+//
+// The mode is chosen once when New is called.
+type Client struct {
+	keyring  *api.TokenManager
+	sockPath string
+	capToken string
+}
+
+// New creates a new Client. If GHTKN_SOCK is set, the Client runs in socket
+// mode and forwards token requests to the daemon at that path; otherwise it
+// runs in keyring mode using the local OAuth device flow.
+func New() *Client {
+	if sock := os.Getenv(socket.EnvSock); sock != "" {
+		return &Client{
+			sockPath: sock,
+			capToken: os.Getenv(socket.EnvCapToken),
+		}
+	}
+	return &Client{keyring: api.New(api.NewInput())}
+}
+
+// Get retrieves an access token. In keyring mode it returns the cached token
+// or runs the device flow. In socket mode it forwards the request to the
+// daemon, returning the token and a minimal AppConfig containing only the
+// app name (the daemon owns the full configuration).
+func (c *Client) Get(ctx context.Context, logger *slog.Logger, input *InputGet) (*AccessToken, *AppConfig, error) {
+	if c.sockPath != "" {
+		return c.getViaSocket(ctx, input)
+	}
+	return c.keyring.Get(ctx, logger, input)
+}
+
+func (c *Client) getViaSocket(ctx context.Context, input *InputGet) (*AccessToken, *AppConfig, error) {
+	if input == nil {
+		input = &InputGet{}
+	}
+	appName := input.AppName
+	if appName == "" {
+		appName = os.Getenv("GHTKN_APP")
+	}
+	resp, err := socket.FetchToken(ctx, c.sockPath, c.capToken, &socket.TokenRequest{App: appName})
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch token from ghtkn daemon: %w", err)
+	}
+	token := &AccessToken{
+		AccessToken:    resp.AccessToken,
+		ExpirationDate: resp.ExpirationDate,
+		Login:          resp.Login,
+	}
+	return token, &AppConfig{Name: appName}, nil
+}
+
+// SetLogger updates the logger used by the keyring backend. It is a no-op in
+// socket mode because logging happens daemon-side.
+func (c *Client) SetLogger(logger *Logger) {
+	if c.keyring != nil {
+		c.keyring.SetLogger(logger)
+	}
+}
+
+// SetDeviceCodeUI updates the device code UI used by the keyring backend. It
+// is a no-op in socket mode because the device flow runs on the daemon host.
+func (c *Client) SetDeviceCodeUI(ui DeviceCodeUI) {
+	if c.keyring != nil {
+		c.keyring.SetDeviceCodeUI(ui)
+	}
+}
+
+// SetBrowser updates the browser used by the keyring backend. It is a no-op
+// in socket mode because the device flow runs on the daemon host.
+func (c *Client) SetBrowser(b Browser) {
+	if c.keyring != nil {
+		c.keyring.SetBrowser(b)
+	}
+}
 
 // GetConfigPath returns the default configuration file path for ghtkn.
 func GetConfigPath() (string, error) {

--- a/ghtkn/client_test.go
+++ b/ghtkn/client_test.go
@@ -1,0 +1,146 @@
+package ghtkn_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/socket"
+)
+
+// shortTempDir returns a temp directory under /tmp that is short enough to
+// hold a Unix socket path within macOS's 104-byte sun_path limit.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "g")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func TestNew(t *testing.T) {
+	t.Setenv(socket.EnvSock, "")
+	if c := ghtkn.New(); c == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+func TestClient_Get_socketMode(t *testing.T) {
+	expires := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	// Spin up a fake daemon on a Unix socket.
+	sockPath := filepath.Join(shortTempDir(t), "s")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	var gotApp, gotAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc(socket.PathToken, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		req := &socket.TokenRequest{}
+		_ = json.NewDecoder(r.Body).Decode(req)
+		gotApp = req.App
+		_ = json.NewEncoder(w).Encode(&socket.TokenResponse{
+			AccessToken:    "ghs_xxx",
+			Login:          "octocat",
+			ExpirationDate: expires,
+		})
+	})
+	srv := &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: mux, ReadHeaderTimeout: time.Second},
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	t.Setenv(socket.EnvSock, sockPath)
+	t.Setenv(socket.EnvCapToken, "cap-token")
+
+	client := ghtkn.New()
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+
+	token, app, err := client.Get(t.Context(), logger, &ghtkn.InputGet{AppName: "my-app"})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	wantToken := &ghtkn.AccessToken{
+		AccessToken:    "ghs_xxx",
+		Login:          "octocat",
+		ExpirationDate: expires,
+	}
+	if diff := cmp.Diff(wantToken, token); diff != "" {
+		t.Errorf("token mismatch (-want +got):\n%s", diff)
+	}
+	if app == nil || app.Name != "my-app" {
+		t.Errorf("app = %+v, want Name=my-app", app)
+	}
+	if gotApp != "my-app" {
+		t.Errorf("daemon received app = %q, want my-app", gotApp)
+	}
+	if gotAuth != "Bearer cap-token" {
+		t.Errorf("daemon received Authorization = %q, want Bearer cap-token", gotAuth)
+	}
+}
+
+func TestClient_Get_socketMode_appFromEnv(t *testing.T) {
+	expires := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	sockPath := filepath.Join(shortTempDir(t), "s")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	var gotApp string
+	mux := http.NewServeMux()
+	mux.HandleFunc(socket.PathToken, func(w http.ResponseWriter, r *http.Request) {
+		req := &socket.TokenRequest{}
+		_ = json.NewDecoder(r.Body).Decode(req)
+		gotApp = req.App
+		_ = json.NewEncoder(w).Encode(&socket.TokenResponse{
+			AccessToken:    "ghs_xxx",
+			ExpirationDate: expires,
+		})
+	})
+	srv := &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: mux, ReadHeaderTimeout: time.Second},
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	t.Setenv(socket.EnvSock, sockPath)
+	t.Setenv(socket.EnvCapToken, "")
+	t.Setenv("GHTKN_APP", "env-app")
+
+	client := ghtkn.New()
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+
+	if _, _, err := client.Get(t.Context(), logger, nil); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if gotApp != "env-app" {
+		t.Errorf("daemon received app = %q, want env-app", gotApp)
+	}
+}
+
+func TestClient_Setters_socketModeNoOp(t *testing.T) {
+	t.Setenv(socket.EnvSock, "/nonexistent.sock")
+	client := ghtkn.New()
+	// Should not panic in socket mode even though the keyring backend is nil.
+	client.SetLogger(&ghtkn.Logger{})
+	client.SetDeviceCodeUI(nil)
+	client.SetBrowser(nil)
+}

--- a/ghtkn/socket/client.go
+++ b/ghtkn/socket/client.go
@@ -1,0 +1,99 @@
+package socket
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+// httpScheme is a placeholder host used when building URLs for the Unix socket
+// transport. The transport ignores the host, but net/http requires a valid URL.
+const unixHTTPBase = "http://unix"
+
+// NewClient returns an *http.Client whose Transport dials the Unix socket at
+// sockPath. The returned client should be used with URLs that have any host
+// (the host is ignored); helpers in this package construct such URLs as
+// "http://unix" + path.
+func NewClient(sockPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", sockPath)
+			},
+		},
+	}
+}
+
+// Error is returned by socket helpers when the daemon responds with a non-2xx
+// status. It carries both the HTTP status and the structured ErrorResponse
+// fields when the body could be decoded.
+type Error struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("ghtkn socket: %d %s: %s", e.Status, e.Code, e.Message)
+	}
+	if e.Message != "" {
+		return fmt.Sprintf("ghtkn socket: %d: %s", e.Status, e.Message)
+	}
+	return fmt.Sprintf("ghtkn socket: %d", e.Status)
+}
+
+// FetchToken posts a TokenRequest to the daemon at sockPath, presenting
+// capToken as a Bearer credential, and returns the decoded TokenResponse. A
+// non-2xx response is reported as an *Error.
+func FetchToken(ctx context.Context, sockPath, capToken string, req *TokenRequest) (*TokenResponse, error) {
+	if req == nil {
+		return nil, errors.New("request is required")
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal token request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, unixHTTPBase+PathToken, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if capToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+capToken)
+	}
+	resp, err := NewClient(sockPath).Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("send token request: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, decodeError(resp.StatusCode, respBody)
+	}
+	tokenResp := &TokenResponse{}
+	if err := json.Unmarshal(respBody, tokenResp); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	return tokenResp, nil
+}
+
+// decodeError builds an *Error from a non-2xx response body. If the body is
+// not a JSON ErrorResponse, the raw body is used as the message.
+func decodeError(status int, body []byte) error {
+	errResp := &ErrorResponse{}
+	if err := json.Unmarshal(body, errResp); err == nil && (errResp.Code != "" || errResp.Message != "") {
+		return &Error{Status: status, Code: errResp.Code, Message: errResp.Message}
+	}
+	return &Error{Status: status, Message: string(bytes.TrimSpace(body))}
+}

--- a/ghtkn/socket/client_test.go
+++ b/ghtkn/socket/client_test.go
@@ -1,0 +1,213 @@
+package socket_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/socket"
+)
+
+// startUnixServer starts an httptest server bound to a Unix socket and returns
+// the socket path. The server is closed on test cleanup.
+//
+// The socket lives in /tmp rather than t.TempDir() because macOS limits Unix
+// socket paths to 104 bytes and t.TempDir() paths under /var/folders are too
+// long when combined with verbose test names.
+func startUnixServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "g")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sockPath := filepath.Join(dir, "s")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	srv := &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: handler, ReadHeaderTimeout: time.Second},
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return sockPath
+}
+
+func TestFetchToken(t *testing.T) {
+	t.Parallel()
+	expires := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		capToken     string
+		req          *socket.TokenRequest
+		handler      http.HandlerFunc
+		want         *socket.TokenResponse
+		wantErr      bool
+		wantErrAs    any
+		wantStatus   int
+		wantErrCode  string
+		wantPath     string
+		wantMethod   string
+		wantApp      string
+		wantAuthHdr  string
+		wantContent  string
+		nilRequest   bool
+		emptyCapHdr  bool
+		notValidJSON bool
+	}{
+		{
+			name:     "success",
+			capToken: "cap-123",
+			req:      &socket.TokenRequest{App: "my-app"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != socket.PathToken {
+					t.Errorf("path = %q, want %q", r.URL.Path, socket.PathToken)
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %q, want POST", r.Method)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer cap-123" {
+					t.Errorf("Authorization = %q", got)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/json" {
+					t.Errorf("Content-Type = %q", got)
+				}
+				body, _ := io.ReadAll(r.Body)
+				gotReq := &socket.TokenRequest{}
+				if err := json.Unmarshal(body, gotReq); err != nil {
+					t.Errorf("decode body: %v", err)
+				}
+				if gotReq.App != "my-app" {
+					t.Errorf("app = %q, want my-app", gotReq.App)
+				}
+				_ = json.NewEncoder(w).Encode(&socket.TokenResponse{
+					AccessToken:    "ghs_xxx",
+					Login:          "octocat",
+					ExpirationDate: expires,
+				})
+			},
+			want: &socket.TokenResponse{
+				AccessToken:    "ghs_xxx",
+				Login:          "octocat",
+				ExpirationDate: expires,
+			},
+		},
+		{
+			name:     "no capability token omits Authorization header",
+			capToken: "",
+			req:      &socket.TokenRequest{App: "my-app"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("Authorization"); got != "" {
+					t.Errorf("Authorization should be empty, got %q", got)
+				}
+				_ = json.NewEncoder(w).Encode(&socket.TokenResponse{
+					AccessToken:    "ghs_xxx",
+					ExpirationDate: expires,
+				})
+			},
+			want: &socket.TokenResponse{
+				AccessToken:    "ghs_xxx",
+				ExpirationDate: expires,
+			},
+		},
+		{
+			name:     "structured error response",
+			capToken: "cap-123",
+			req:      &socket.TokenRequest{App: "my-app"},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(&socket.ErrorResponse{
+					Code:    "forbidden",
+					Message: "app not allowed",
+				})
+			},
+			wantErr:     true,
+			wantStatus:  http.StatusForbidden,
+			wantErrCode: "forbidden",
+		},
+		{
+			name:     "non-json error body",
+			capToken: "cap-123",
+			req:      &socket.TokenRequest{App: "my-app"},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("boom"))
+			},
+			wantErr:    true,
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "nil request",
+			capToken:   "cap-123",
+			req:        nil,
+			handler:    func(_ http.ResponseWriter, _ *http.Request) { t.Error("handler should not be called") },
+			wantErr:    true,
+			nilRequest: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sockPath := startUnixServer(t, tt.handler)
+			got, err := socket.FetchToken(t.Context(), sockPath, tt.capToken, tt.req)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantStatus != 0 {
+					var sockErr *socket.Error
+					if !errors.As(err, &sockErr) {
+						t.Fatalf("error is not *socket.Error: %v", err)
+					}
+					if sockErr.Status != tt.wantStatus {
+						t.Errorf("status = %d, want %d", sockErr.Status, tt.wantStatus)
+					}
+					if tt.wantErrCode != "" && sockErr.Code != tt.wantErrCode {
+						t.Errorf("code = %q, want %q", sockErr.Code, tt.wantErrCode)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestError_Error(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  *socket.Error
+		want string
+	}{
+		{"with code", &socket.Error{Status: 403, Code: "forbidden", Message: "no"}, "ghtkn socket: 403 forbidden: no"},
+		{"message only", &socket.Error{Status: 500, Message: "boom"}, "ghtkn socket: 500: boom"},
+		{"status only", &socket.Error{Status: 502}, "ghtkn socket: 502"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/ghtkn/socket/protocol.go
+++ b/ghtkn/socket/protocol.go
@@ -1,0 +1,81 @@
+// Package socket defines the wire protocol and client for the ghtkn daemon
+// socket. The protocol is HTTP over a Unix domain socket; types in this package
+// are exchanged as JSON request and response bodies.
+//
+// The package is split between two endpoints exposed by the daemon:
+//
+//   - Token socket: clients in containers/VMs call PathToken with a capability
+//     token to retrieve a GitHub access token.
+//   - Mgmt socket: host-side tooling calls PathSessions to issue and revoke
+//     capability tokens.
+package socket
+
+import "time"
+
+// Endpoint paths on the daemon HTTP API.
+const (
+	// PathToken is the token endpoint. POST with a TokenRequest body and an
+	// "Authorization: Bearer <capability-token>" header to receive a
+	// TokenResponse.
+	PathToken = "/v1/token"
+	// PathSessions is the management endpoint. POST with an IssueRequest body
+	// to mint a capability token. DELETE PathSessions+"/{token}" to revoke.
+	// GET to list active capabilities. Only exposed on the mgmt socket.
+	PathSessions = "/v1/sessions"
+)
+
+// Environment variables read by the socket-mode client.
+const (
+	// EnvSock holds the path to the daemon token socket. When set, the SDK
+	// switches to socket mode instead of accessing the keyring directly.
+	EnvSock = "GHTKN_SOCK"
+	// EnvCapToken holds the capability token presented to the daemon.
+	EnvCapToken = "GHTKN_CAP_TOKEN"
+)
+
+// TokenRequest is the request body for POST PathToken.
+type TokenRequest struct {
+	// App is the configured app name to retrieve a token for.
+	App string `json:"app"`
+}
+
+// TokenResponse is the response body for POST PathToken.
+type TokenResponse struct {
+	// AccessToken is the GitHub App user access token.
+	AccessToken string `json:"token"`
+	// Login is the GitHub login associated with the token. May be empty if
+	// the daemon could not resolve it.
+	Login string `json:"login,omitempty"`
+	// ExpirationDate is when the access token expires.
+	ExpirationDate time.Time `json:"expires_at"`
+}
+
+// IssueRequest is the request body for POST PathSessions on the mgmt socket.
+type IssueRequest struct {
+	// AppAllowlist limits which app names the issued capability token may
+	// request tokens for. An empty list means no apps are allowed.
+	AppAllowlist []string `json:"app_allowlist"`
+	// TTL is how long the capability token remains valid.
+	TTL time.Duration `json:"ttl"`
+	// MaxRequests caps how many token requests the capability token may make.
+	// Zero means unlimited.
+	MaxRequests int `json:"max_requests,omitempty"`
+	// Label is an optional human-readable label recorded in audit logs.
+	Label string `json:"label,omitempty"`
+}
+
+// IssueResponse is the response body for POST PathSessions.
+type IssueResponse struct {
+	// CapabilityToken is the freshly minted capability token.
+	CapabilityToken string `json:"capability_token"`
+	// ExpiresAt is the absolute expiration time of the capability token.
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// ErrorResponse is returned by the daemon on non-2xx responses.
+type ErrorResponse struct {
+	// Code is a machine-readable identifier (e.g. "unauthorized", "forbidden").
+	Code string `json:"code"`
+	// Message is a human-readable description.
+	Message string `json:"message"`
+}


### PR DESCRIPTION
## Summary

- Wraps the existing `api.TokenManager` in a new `ghtkn.Client` that picks a backend at construction time. By default it keeps the current keyring + OAuth device flow behavior; if `GHTKN_SOCK` is set it switches to socket mode and forwards token requests to a ghtkn daemon over a Unix socket, presenting `GHTKN_CAP_TOKEN` as a Bearer credential.
- Adds a new `ghtkn/socket` package that defines the daemon's HTTP-over-Unix wire protocol (`TokenRequest`/`TokenResponse`, `IssueRequest`/`IssueResponse`, `ErrorResponse`, endpoint paths, env-var names) and a `FetchToken` helper that issues the request and decodes structured `*socket.Error` values for non-2xx responses.
- Adds project-level Claude Code `PostToolUse` hooks that run `go vet`, `go test -race`, and `golangci-lint` after edits.

## Background

This is the SDK-side surface of a daemon-based token-retrieval architecture: a long-running ghtkn daemon owns the keyring and configuration on the host, and short-lived clients (containers, VMs, CI shells) reach it through a Unix socket using a capability token issued by host-side tooling. From the SDK consumer's perspective, switching modes only requires setting `GHTKN_SOCK` (and optionally `GHTKN_CAP_TOKEN`); the `Client.Get` signature is unchanged.

## Diff highlights

### `ghtkn/client.go`

- Removes the old type alias `Client = api.TokenManager` and replaces it with a concrete `Client` struct holding either a keyring `*api.TokenManager` or a `(sockPath, capToken)` pair.
- `New()` reads `socket.EnvSock` once. Non-empty -> socket mode; empty -> existing keyring mode (`api.New(api.NewInput())`).
- `Get(ctx, logger, *InputGet)`: in socket mode, resolves the app name from `input.AppName` or falls back to `GHTKN_APP`, calls `socket.FetchToken`, and maps the response into the existing `AccessToken` / `AppConfig` types (the daemon owns the full app config; the SDK only surfaces the name).
- `SetLogger`, `SetDeviceCodeUI`, `SetBrowser` become no-ops in socket mode (those concerns live on the daemon host); they still delegate to the underlying `TokenManager` in keyring mode.

### `ghtkn/socket/protocol.go`

- Endpoint paths: `PathToken = "/v1/token"` (clients) and `PathSessions = "/v1/sessions"` (mgmt only).
- Env vars: `EnvSock = "GHTKN_SOCK"`, `EnvCapToken = "GHTKN_CAP_TOKEN"`.
- Request/response shapes for the token endpoint and the session-mgmt endpoint, plus a shared `ErrorResponse` for non-2xx daemon replies. `IssueRequest` carries an `AppAllowlist`, `TTL`, optional `MaxRequests`, and `Label` so capability tokens can be scoped per consumer.

### `ghtkn/socket/client.go`

- `NewClient(sockPath)` returns an `*http.Client` whose `Transport.DialContext` dials `unix://sockPath`; URLs are built against the `http://unix` placeholder host since `net/http` requires a valid URL.
- `FetchToken(ctx, sockPath, capToken, *TokenRequest)` marshals JSON, sets `Content-Type: application/json` and (when present) `Authorization: Bearer <capToken>`, and decodes the response.
- Non-2xx responses are reported as `*socket.Error` carrying status + decoded `Code`/`Message` (or the raw body when the body isn't a JSON `ErrorResponse`); `errors.As` works against this type.

### Tests

- `ghtkn/client_test.go`: spins up a real Unix-socket-backed `httptest.Server` and exercises socket mode end-to-end, including the `GHTKN_APP` env fallback for the app name and a no-op assertion for the setters in socket mode (must not panic when the keyring backend is nil). Sockets live under `/tmp` to stay within macOS's 104-byte `sun_path` limit.
- `ghtkn/socket/client_test.go`: table-driven coverage of `FetchToken` (success path, omitted Authorization when no cap token, structured error decoding, non-JSON error body, nil-request guard) and `Error.Error()` formatting variants.
- `cmdx t` reports 73.9% coverage in `ghtkn` and 86.1% in `ghtkn/socket`.

### `.claude/settings.json`

- Adds a `PostToolUse` hook on `Edit|Write|MultiEdit` that runs `go vet ./... && go test -race -covermode=atomic ./... && golangci-lint fmt && golangci-lint run`. Reviewers who don't want this opt-in can drop the second commit.

## Test plan

- [x] `cmdx v` (go vet)
- [x] `cmdx t` (go test -race ./...) — all green
- [ ] Manual smoke: run against a real ghtkn daemon socket
- [ ] Confirm reviewers are OK with committing `.claude/settings.json`