### PR TITLE
refactor: decouple public ghtkn API from internal types

### DIFF
--- a/ghtkn/adapter.go
+++ b/ghtkn/adapter.go
@@ -1,0 +1,20 @@
+package ghtkn
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
+)
+
+// deviceCodeUIAdapter adapts a public DeviceCodeUI to the internal deviceflow.DeviceCodeUI
+// interface, converting the internal device code response to its public representation
+// before delegating to the user-provided UI.
+type deviceCodeUIAdapter struct {
+	ui DeviceCodeUI
+}
+
+func (a *deviceCodeUIAdapter) Show(ctx context.Context, logger *slog.Logger, deviceCode *deviceflow.DeviceCodeResponse, expirationDate time.Time) error {
+	return a.ui.Show(ctx, logger, fromDeviceCodeResponse(deviceCode), expirationDate) //nolint:wrapcheck
+}

--- a/ghtkn/adapter_test.go
+++ b/ghtkn/adapter_test.go
@@ -1,0 +1,52 @@
+package ghtkn
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
+)
+
+// fakeDeviceCodeUI records the device code response it receives.
+type fakeDeviceCodeUI struct {
+	got *DeviceCodeResponse
+	err error
+}
+
+func (f *fakeDeviceCodeUI) Show(_ context.Context, _ *slog.Logger, deviceCode *DeviceCodeResponse, _ time.Time) error {
+	f.got = deviceCode
+	return f.err
+}
+
+func TestDeviceCodeUIAdapter_Show(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeDeviceCodeUI{}
+	adapter := &deviceCodeUIAdapter{ui: fake}
+
+	internal := &deviceflow.DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "uc",
+		VerificationURI: "https://github.com/login/device",
+		ExpiresIn:       900,
+		Interval:        5,
+	}
+
+	if err := adapter.Show(t.Context(), nil, internal, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := &DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "uc",
+		VerificationURI: "https://github.com/login/device",
+		ExpiresIn:       900,
+		Interval:        5,
+	}
+	if diff := cmp.Diff(want, fake.got); diff != "" {
+		t.Error(diff)
+	}
+}

--- a/ghtkn/client.go
+++ b/ghtkn/client.go
@@ -3,35 +3,57 @@
 package ghtkn
 
 import (
+	"context"
+	"log/slog"
 	"os"
 	"runtime"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/api"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/browser"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/config"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/keyring"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/log"
+	"golang.org/x/oauth2"
 )
 
-// New creates a new Client instance with the provided input configuration.
-func New() *Client {
-	return api.New(api.NewInput())
+// Client retrieves GitHub App access tokens.
+// It wraps the internal token manager so that the public API is decoupled from
+// internal implementation types.
+type Client struct {
+	tm *api.TokenManager
 }
 
-type (
-	AccessToken        = keyring.AccessToken
-	AppConfig          = config.App
-	Config             = config.Config
-	Logger             = log.Logger
-	DeviceCodeUI       = deviceflow.DeviceCodeUI
-	Browser            = deviceflow.Browser
-	DeviceCodeResponse = deviceflow.DeviceCodeResponse
-	DefaultBrowser     = browser.Browser
-	ClientIDReader     = api.PasswordReader
-	InputGet           = api.InputGet
-	Client             = api.TokenManager
-)
+// New creates a new Client instance with default production dependencies.
+func New() *Client {
+	return &Client{
+		tm: api.New(api.NewInput()),
+	}
+}
+
+// Get retrieves a GitHub App access token, creating or renewing it when needed.
+// It returns the access token and the resolved app configuration.
+func (c *Client) Get(ctx context.Context, logger *slog.Logger, input *InputGet) (*AccessToken, *AppConfig, error) {
+	token, app, err := c.tm.Get(ctx, logger, toAPIInputGet(input))
+	return fromKeyringAccessToken(token), fromConfigApp(app), err //nolint:wrapcheck
+}
+
+// TokenSource returns an oauth2.TokenSource that retrieves and caches access tokens
+// through this client. It can be used with OAuth2-aware HTTP clients.
+func (c *Client) TokenSource(logger *slog.Logger, input *InputGet) oauth2.TokenSource {
+	return c.tm.TokenSource(logger, toAPIInputGet(input))
+}
+
+// SetLogger sets the hook functions invoked by the SDK to report notable events.
+func (c *Client) SetLogger(logger *Logger) {
+	c.tm.SetLogger(toLogLogger(logger))
+}
+
+// SetDeviceCodeUI sets the UI implementation used to display device flow information.
+func (c *Client) SetDeviceCodeUI(ui DeviceCodeUI) {
+	c.tm.SetDeviceCodeUI(&deviceCodeUIAdapter{ui: ui})
+}
+
+// SetBrowser sets the implementation used to open the GitHub verification URL.
+func (c *Client) SetBrowser(b Browser) {
+	c.tm.SetBrowser(b)
+}
 
 // GetConfigPath returns the default configuration file path for ghtkn.
 func GetConfigPath() (string, error) {

--- a/ghtkn/client_test.go
+++ b/ghtkn/client_test.go
@@ -1,0 +1,53 @@
+package ghtkn_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	if c := ghtkn.New(); c == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+// stubBrowser is a user-defined Browser implementation, verifying that a value
+// satisfying ghtkn.Browser is accepted by Client.SetBrowser.
+type stubBrowser struct{}
+
+func (stubBrowser) Open(_ context.Context, _ *slog.Logger, _ string) error { return nil }
+
+func TestClient_SetBrowser(t *testing.T) {
+	t.Parallel()
+
+	c := ghtkn.New()
+	// Must compile and not panic: a public Browser implementation is accepted.
+	c.SetBrowser(stubBrowser{})
+	c.SetBrowser(&ghtkn.DefaultBrowser{})
+}
+
+type stubDeviceCodeUI struct{}
+
+func (stubDeviceCodeUI) Show(_ context.Context, _ *slog.Logger, _ *ghtkn.DeviceCodeResponse, _ time.Time) error {
+	return nil
+}
+
+func TestClient_SetDeviceCodeUIAndLogger(t *testing.T) {
+	t.Parallel()
+
+	c := ghtkn.New()
+	c.SetLogger(&ghtkn.Logger{})
+	c.SetDeviceCodeUI(stubDeviceCodeUI{})
+}
+
+func TestDefaultBrowser_ImplementsBrowser(t *testing.T) {
+	t.Parallel()
+
+	var _ ghtkn.Browser = &ghtkn.DefaultBrowser{}
+}

--- a/ghtkn/convert.go
+++ b/ghtkn/convert.go
@@ -1,0 +1,74 @@
+package ghtkn
+
+import (
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/api"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/config"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/keyring"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/log"
+)
+
+// fromKeyringAccessToken converts an internal keyring.AccessToken to the public AccessToken.
+func fromKeyringAccessToken(t *keyring.AccessToken) *AccessToken {
+	if t == nil {
+		return nil
+	}
+	return &AccessToken{
+		AccessToken:    t.AccessToken,
+		ExpirationDate: t.ExpirationDate,
+		Login:          t.Login,
+	}
+}
+
+// fromConfigApp converts an internal config.App to the public AppConfig.
+func fromConfigApp(a *config.App) *AppConfig {
+	if a == nil {
+		return nil
+	}
+	return &AppConfig{
+		Name:     a.Name,
+		ClientID: a.ClientID,
+		GitOwner: a.GitOwner,
+	}
+}
+
+// fromDeviceCodeResponse converts an internal deviceflow.DeviceCodeResponse to the public DeviceCodeResponse.
+func fromDeviceCodeResponse(d *deviceflow.DeviceCodeResponse) *DeviceCodeResponse {
+	if d == nil {
+		return nil
+	}
+	return &DeviceCodeResponse{
+		DeviceCode:      d.DeviceCode,
+		UserCode:        d.UserCode,
+		VerificationURI: d.VerificationURI,
+		ExpiresIn:       d.ExpiresIn,
+		Interval:        d.Interval,
+	}
+}
+
+// toAPIInputGet converts the public InputGet to the internal api.InputGet.
+func toAPIInputGet(in *InputGet) *api.InputGet {
+	if in == nil {
+		return nil
+	}
+	return &api.InputGet{
+		KeyringService: in.KeyringService,
+		AppName:        in.AppName,
+		ConfigFilePath: in.ConfigFilePath,
+		AppOwner:       in.AppOwner,
+		MinExpiration:  in.MinExpiration,
+	}
+}
+
+// toLogLogger converts the public Logger to the internal log.Logger.
+func toLogLogger(l *Logger) *log.Logger {
+	if l == nil {
+		return nil
+	}
+	return &log.Logger{
+		Expire:                            l.Expire,
+		FailedToOpenBrowser:               l.FailedToOpenBrowser,
+		FailedToGetAccessTokenFromKeyring: l.FailedToGetAccessTokenFromKeyring,
+		AccessTokenIsNotFoundInKeyring:    l.AccessTokenIsNotFoundInKeyring,
+	}
+}

--- a/ghtkn/convert_test.go
+++ b/ghtkn/convert_test.go
@@ -1,0 +1,129 @@
+package ghtkn
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/api"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/config"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/keyring"
+)
+
+func TestFromKeyringAccessToken(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	if got := fromKeyringAccessToken(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+
+	got := fromKeyringAccessToken(&keyring.AccessToken{
+		AccessToken:    "token",
+		ExpirationDate: exp,
+		Login:          "octocat",
+	})
+	want := &AccessToken{AccessToken: "token", ExpirationDate: exp, Login: "octocat"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestFromConfigApp(t *testing.T) {
+	t.Parallel()
+
+	if got := fromConfigApp(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+
+	got := fromConfigApp(&config.App{Name: "app", ClientID: "cid", GitOwner: "owner"})
+	want := &AppConfig{Name: "app", ClientID: "cid", GitOwner: "owner"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestFromDeviceCodeResponse(t *testing.T) {
+	t.Parallel()
+
+	if got := fromDeviceCodeResponse(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+
+	got := fromDeviceCodeResponse(&deviceflow.DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "uc",
+		VerificationURI: "https://github.com/login/device",
+		ExpiresIn:       900,
+		Interval:        5,
+	})
+	want := &DeviceCodeResponse{
+		DeviceCode:      "dc",
+		UserCode:        "uc",
+		VerificationURI: "https://github.com/login/device",
+		ExpiresIn:       900,
+		Interval:        5,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestToAPIInputGet(t *testing.T) {
+	t.Parallel()
+
+	if got := toAPIInputGet(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+
+	got := toAPIInputGet(&InputGet{
+		KeyringService: "svc",
+		AppName:        "app",
+		ConfigFilePath: "/path/to/config.yaml",
+		AppOwner:       "owner",
+		MinExpiration:  time.Hour,
+	})
+	want := &api.InputGet{
+		KeyringService: "svc",
+		AppName:        "app",
+		ConfigFilePath: "/path/to/config.yaml",
+		AppOwner:       "owner",
+		MinExpiration:  time.Hour,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestToLogLogger(t *testing.T) {
+	t.Parallel()
+
+	if got := toLogLogger(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+
+	called := map[string]bool{}
+	l := &Logger{
+		Expire:                            func(*slog.Logger, time.Time) { called["expire"] = true },
+		FailedToOpenBrowser:               func(*slog.Logger, error) { called["browser"] = true },
+		FailedToGetAccessTokenFromKeyring: func(*slog.Logger, error) { called["keyring"] = true },
+		AccessTokenIsNotFoundInKeyring:    func(*slog.Logger) { called["notfound"] = true },
+	}
+	got := toLogLogger(l)
+	if got == nil {
+		t.Fatal("toLogLogger returned nil")
+	}
+	// The function fields should be carried over (verified by invoking them).
+	got.Expire(nil, time.Time{})
+	got.FailedToOpenBrowser(nil, nil)
+	got.FailedToGetAccessTokenFromKeyring(nil, nil)
+	got.AccessTokenIsNotFoundInKeyring(nil)
+	for _, k := range []string{"expire", "browser", "keyring", "notfound"} {
+		if !called[k] {
+			t.Errorf("function field %q was not carried over", k)
+		}
+	}
+}

--- a/ghtkn/types.go
+++ b/ghtkn/types.go
@@ -1,0 +1,90 @@
+package ghtkn
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/browser"
+)
+
+// AccessToken represents a GitHub App access token returned by the SDK.
+// It contains the token value, its expiration date, and the associated GitHub user login.
+type AccessToken struct {
+	AccessToken    string
+	ExpirationDate time.Time
+	Login          string
+}
+
+// AppConfig represents a GitHub App configuration.
+// Each app must have a unique name and a client ID for authentication.
+type AppConfig struct {
+	Name     string `json:"name"`
+	ClientID string `json:"client_id" yaml:"client_id"`
+	GitOwner string `json:"git_owner,omitempty" yaml:"git_owner"`
+}
+
+// Config represents the main configuration structure for ghtkn.
+// It contains a list of GitHub Apps.
+type Config struct {
+	Apps []*AppConfig `json:"apps"`
+}
+
+// InputGet contains the input parameters for token retrieval operations.
+// It provides configuration options for specifying which app to use,
+// where to find configuration, and token expiration requirements.
+type InputGet struct {
+	KeyringService string        // Service name for keyring storage (defaults to the SDK's default)
+	AppName        string        // Name of the app to use (defaults to GHTKN_APP environment variable)
+	ConfigFilePath string        // Path to configuration file (auto-detected if empty)
+	AppOwner       string        // GitHub App Owner
+	MinExpiration  time.Duration // Minimum time before token expiration to trigger renewal
+}
+
+// Logger holds hook functions invoked by the SDK to report notable events.
+// Each field is optional; nil functions are not called.
+type Logger struct {
+	// Expire logs when an access token expiration date is processed.
+	Expire func(logger *slog.Logger, exDate time.Time)
+	// FailedToOpenBrowser logs when the browser cannot be opened for authentication.
+	FailedToOpenBrowser func(logger *slog.Logger, err error)
+	// FailedToGetAccessTokenFromKeyring logs when access token retrieval from keyring fails.
+	FailedToGetAccessTokenFromKeyring func(logger *slog.Logger, err error)
+	// AccessTokenIsNotFoundInKeyring logs when no access token is found in the keyring.
+	AccessTokenIsNotFoundInKeyring func(logger *slog.Logger)
+}
+
+// DeviceCodeResponse represents the response from GitHub's device code endpoint.
+// It contains the device code and user code needed for authentication.
+type DeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// DeviceCodeUI provides an interface for displaying device flow information to users.
+type DeviceCodeUI interface {
+	Show(ctx context.Context, logger *slog.Logger, deviceCode *DeviceCodeResponse, expirationDate time.Time) error
+}
+
+// Browser provides an interface for opening URLs in a web browser.
+// This is used to open the GitHub verification URL during device flow authentication.
+type Browser interface {
+	Open(ctx context.Context, logger *slog.Logger, url string) error
+}
+
+// ClientIDReader provides an interface for reading a client ID for an app.
+type ClientIDReader interface {
+	Read(ctx context.Context, logger *slog.Logger, app *AppConfig) (string, error)
+}
+
+// DefaultBrowser is the default Browser implementation that opens URLs using
+// the operating system's standard browser-opening command.
+type DefaultBrowser struct{}
+
+// Open opens the given URL in the operating system's default web browser.
+func (b *DefaultBrowser) Open(ctx context.Context, logger *slog.Logger, url string) error {
+	return (&browser.Browser{}).Open(ctx, logger, url) //nolint:wrapcheck
+}

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/config/config",
+  "$id": "https://github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config",
   "$ref": "#/$defs/Config",
   "$defs": {
-    "App": {
+    "AppConfig": {
       "properties": {
         "name": {
           "type": "string"
@@ -26,7 +26,7 @@
       "properties": {
         "apps": {
           "items": {
-            "$ref": "#/$defs/App"
+            "$ref": "#/$defs/AppConfig"
           },
           "type": "array"
         }


### PR DESCRIPTION
## Context

The public package `ghtkn` (`ghtkn/client.go`) has so far exposed the types from `ghtkn/internal/*` directly via `type alias`. Because a type alias is **identical** to the internal type, a change intended only for `internal/` can accidentally break the public API.

This PR introduces an **anti-corruption layer**: public types are defined independently within `ghtkn`, and converted to/from internal types at the boundary. This makes it possible to change the internal representation without affecting the public API. All public names, field names, and JSON/yaml tags are preserved, so existing consumers, examples, and config-file validation are not broken.

The dependency direction is one-way only (`ghtkn → internal/*`), so no import cycle occurs.

## Changes (from the base→head diff)

### `ghtkn/client.go`
- Changed `Client` from a type alias (`= api.TokenManager`) to a real wrapper `struct{ tm *api.TokenManager }`.
- Implemented public methods via delegation + conversion:
  - `Get(ctx, *slog.Logger, *InputGet) (*AccessToken, *AppConfig, error)` — converts arguments/return values.
  - `TokenSource(...)` — returns a stable `golang.org/x/oauth2.TokenSource` without exposing the internal `*api.TokenSource`.
  - `SetLogger(*Logger)` / `SetDeviceCodeUI(DeviceCodeUI)` / `SetBrowser(Browser)` / `GetConfigPath()`.

### `ghtkn/types.go` (new)
Defines the public data types and interfaces independently (keeping the old alias names):
- Data types: `AccessToken`, `AppConfig`, `Config`, `InputGet`, `Logger`, `DeviceCodeResponse`
- Interfaces: `DeviceCodeUI`, `Browser`, `ClientIDReader`
- `DefaultBrowser` (delegates to the internal `browser.Browser` in `Open`)
- `AppConfig`/`Config` fully preserve their JSON/yaml tags because `cmd/gen-jsonschema` reflects over them.

### `ghtkn/convert.go` (new)
Conversion functions for `internal ↔ public` (all with nil guards):
`fromKeyringAccessToken`, `fromConfigApp`, `fromDeviceCodeResponse` (internal→public) / `toAPIInputGet`, `toLogLogger` (public→internal).

### `ghtkn/adapter.go` (new)
`deviceCodeUIAdapter` — adapts the public `DeviceCodeUI` to the internal `deviceflow.DeviceCodeUI`, converting the internal device code response to the public type and delegating to the user's implementation.
(`Browser` is an interface containing no internal types, so it is structurally compatible and needs no adapter; `ClientIDReader` is not currently consumed, so it needs no adapter.)

### Tests (new, `ghtkn` package)
- `convert_test.go` — value mapping and nil guards for each conversion function.
- `adapter_test.go` — verifies the conversion in `deviceCodeUIAdapter.Show` using a fake `DeviceCodeUI`.
- `client_test.go` — `New()`, acceptance of `SetBrowser`/`SetDeviceCodeUI`/`SetLogger`, and `DefaultBrowser` satisfying the interface.

Coverage of the `ghtkn` package went from 0% → 80%.

### `json-schema/ghtkn.json` (regenerated)
Only benign diffs: the `$defs` key `App` → `AppConfig` (following the public type name), and `$id` changes from `.../ghtkn/internal/config/config` → `.../ghtkn/config` (the internal path exposure disappears). The **validation constraints** for `name`/`client_id`/`git_owner`/`apps` etc. are **unchanged**, so config-file validation results do not change. Since `cmd/gen-jsonschema` cannot import `ghtkn/internal/*` (it is outside the `ghtkn/` tree), generating from the public types is both unavoidable and appropriate.

## Design Decisions

- The `Validate()` methods on `config.App`/`config.Config` are internal validation logic, so they are kept internal and not ported to the public types (they are unused by examples, etc.). They can be added to the public types if strict compatibility is required.

## Verification

- `cmdx t` (`go test ./... -race`): all pass. `ghtkn` coverage 80.0%.
- `cmdx v` (`go vet ./...`): clean.
- `cmdx l` (`golangci-lint run`): 0 issues.
- `go build ./examples/...`: all examples build **without modification**.
- `cmdx js`: JSON Schema regenerated (only the benign diffs above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
