### PR TITLE
feat: auto-continue the device flow prompt after a 10s timeout

### DIFF
--- a/ghtkn/internal/deviceflow/device_ui.go
+++ b/ghtkn/internal/deviceflow/device_ui.go
@@ -62,6 +62,8 @@ Press Enter to open %s in your browser...
 			return ctx.Err()
 		case err := <-inputCh:
 			return err
+		case <-time.After(10 * time.Second):
+			return nil
 		}
 	}
 	const msgTemplate = `The application uses the device flow to generate your GitHub User Access Token.


### PR DESCRIPTION
## Context

In `ghtkn/internal/deviceflow/device_ui.go`, `simpleOnetimeCodeUI.Show` is what the SDK shows during the GitHub App OAuth device flow: it prints the one-time code (user code) and the verification URL.

When stdin is a terminal, `Show` prints "Press Enter to open … in your browser…" and then blocks in a `select` that only completes when the user presses Enter (`inputCh`) or the context is cancelled (`ctx.Done()`). If the user never responds, it waits forever, so the device flow cannot proceed unattended.

## Change (composed from the base→head diff)

`ghtkn/internal/deviceflow/device_ui.go` — add a timeout case to the terminal-branch `select` in `Show`:

```go
select {
case <-ctx.Done():
    fmt.Fprintln(d.stderr, "Cancelled") //nolint:errcheck
    return ctx.Err()
case err := <-inputCh:
    return err
case <-time.After(10 * time.Second):
    return nil
}
```

After 10 seconds with no input, `Show` returns `nil` and the device flow continues (the caller proceeds to open the verification URL). Pressing Enter and context cancellation behave exactly as before. `time` is already imported, so no new import is needed.

This branch affects only the interactive (terminal) branch; the non-terminal branch still uses `d.waiter.Wait`, unchanged.

## Verification

- `go build ./...`: OK
- `cmdx t` (`go test ./... -race`): all pass (the existing `internal/deviceflow` tests do not exercise the terminal branch, so behavior under test is unchanged)
- `cmdx v` / `cmdx l`: vet clean, golangci-lint 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)