### PR TITLE
refactor: use the builtin max to clamp the polling interval

### DIFF
--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -104,11 +104,7 @@ const additionalInterval = 5 * time.Second
 // It respects the polling interval and handles authorization pending and slow down responses.
 // The polling continues until the device code expires or the user completes authentication.
 func (c *Client) pollForAccessToken(ctx context.Context, logger *slog.Logger, clientID string, deviceCode *pubdeviceflow.DeviceCodeResponse) (*accessTokenResponse, error) {
-	interval := time.Duration(deviceCode.Interval) * time.Second
-	if interval < additionalInterval {
-		interval = additionalInterval
-	}
-
+	interval := max(time.Duration(deviceCode.Interval)*time.Second, additionalInterval)
 	ticker := c.input.NewTicker(interval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Context

In `ghtkn/internal/deviceflow/create.go`, `pollForAccessToken` lower-bounds the polling interval at `additionalInterval` (5s) to avoid hitting GitHub's rate limit. This was written as an explicit `if` clamp.

## Change (composed from the base→head diff)

`ghtkn/internal/deviceflow/create.go` — replace the `if` clamp with the builtin `max()`:

```go
interval := max(time.Duration(deviceCode.Interval)*time.Second, additionalInterval)
```

replacing:

```go
interval := time.Duration(deviceCode.Interval) * time.Second
if interval < additionalInterval {
    interval = additionalInterval
}
```

Behavior is identical — the interval is the larger of the server-provided value and `additionalInterval`. Both operands are `time.Duration`. (`max` is a Go builtin since 1.21; the module's toolchain supports it.)

## Verification

- `go build ./...`: OK
- `cmdx t` (`go test ./... -race`): all pass
- `cmdx v` / `cmdx l`: vet clean, golangci-lint 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)