### PR TITLE
feat: allow disabling the device flow via GHTKN_DISABLE_DEVICE_FLOW

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -17,4 +17,11 @@ type InputGet struct {
 	MinExpiration  time.Duration // Minimum time before token expiration to trigger renewal
 }
 
-var ErrDisableDeviceFlow = errors.New("device flow is disabled")
+// ErrDisableDeviceFlow is returned when a new GitHub App access token is needed
+// but the device flow is disabled via GHTKN_DISABLE_DEVICE_FLOW. The device flow
+// is interactive (it waits for a one-time code), so it can't be completed by a
+// background or non-interactive process such as a coding agent. Rather than
+// blocking, the operation fails immediately. The message instructs a coding
+// agent NOT to run `ghtkn get` itself (it would fail the same way) but to ask
+// the user to run it in their own interactive terminal.
+var ErrDisableDeviceFlow = errors.New("a GitHub App User access token can't be created via Device Flow because it's disabled by GHTKN_DISABLE_DEVICE_FLOW. The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn get` in their own interactive terminal to authenticate")

--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -1,7 +1,10 @@
 // Package api provides the public request types for the ghtkn client.
 package api
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 // InputGet contains the input parameters for token retrieval operations.
 // It provides configuration options for specifying which app to use,
@@ -13,3 +16,5 @@ type InputGet struct {
 	AppOwner       string        // GitHub App Owner
 	MinExpiration  time.Duration // Minimum time before token expiration to trigger renewal
 }
+
+var ErrDisableDeviceFlow = errors.New("device flow is disabled")

--- a/ghtkn/client.go
+++ b/ghtkn/client.go
@@ -31,6 +31,10 @@ type (
 	InputGet           = api.InputGet
 )
 
+// ErrDisableDeviceFlow is returned by Get when the device flow is disabled via
+// the GHTKN_DISABLE_DEVICE_FLOW environment variable. Detect it with errors.Is.
+var ErrDisableDeviceFlow = api.ErrDisableDeviceFlow
+
 // Client retrieves GitHub App access tokens.
 // It wraps the internal token manager so that the public API is decoupled from
 // the internal implementation: changing the internal manager's method signatures

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -157,9 +157,14 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 	return token, true, nil
 }
 
+var ErrDisableDeviceFlow = fmt.Errorf("device flow is disabled")
+
 // createToken generates a new GitHub App access token using the OAuth device flow.
 // It returns a keyring.AccessToken with the token details and expiration date.
 func (tm *TokenManager) createToken(ctx context.Context, logger *slog.Logger, clientID string) (*pubkeyring.AccessToken, error) {
+	if tm.input.Getenv("GHTKN_DISABLE_DEVICE_FLOW") == "true" {
+		return nil, ErrDisableDeviceFlow
+	}
 	tk, err := tm.input.DeviceFlow.Create(ctx, logger, clientID)
 	if err != nil {
 		return nil, err //nolint:wrapcheck

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -157,13 +157,11 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 	return token, true, nil
 }
 
-var ErrDisableDeviceFlow = fmt.Errorf("device flow is disabled")
-
 // createToken generates a new GitHub App access token using the OAuth device flow.
 // It returns a keyring.AccessToken with the token details and expiration date.
 func (tm *TokenManager) createToken(ctx context.Context, logger *slog.Logger, clientID string) (*pubkeyring.AccessToken, error) {
 	if tm.input.Getenv("GHTKN_DISABLE_DEVICE_FLOW") == "true" {
-		return nil, ErrDisableDeviceFlow
+		return nil, pubapi.ErrDisableDeviceFlow
 	}
 	tk, err := tm.input.DeviceFlow.Create(ctx, logger, clientID)
 	if err != nil {

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -136,6 +136,7 @@ func TestController_createToken(t *testing.T) {
 
 			input := &Input{
 				DeviceFlow: tt.client,
+				Getenv:     func(string) string { return "" },
 			}
 			tm := &TokenManager{input: input}
 

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	pubapi "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/api"
 	pubdeviceflow "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
 	pubkeyring "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/keyring"
@@ -153,5 +154,34 @@ func TestController_createToken(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestController_createToken_disableDeviceFlow(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		DeviceFlow: &testDeviceFlow{
+			token: &deviceflow.AccessToken{
+				AccessToken:    "should-not-be-used",
+				ExpirationDate: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+			},
+		},
+		Getenv: func(key string) string {
+			if key == "GHTKN_DISABLE_DEVICE_FLOW" {
+				return "true"
+			}
+			return ""
+		},
+	}
+	tm := &TokenManager{input: input}
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+
+	got, err := tm.createToken(t.Context(), logger, "test-client-id")
+	if !errors.Is(err, pubapi.ErrDisableDeviceFlow) {
+		t.Errorf("createToken() error = %v, want ErrDisableDeviceFlow", err)
+	}
+	if got != nil {
+		t.Errorf("createToken() = %v, want nil", got)
 	}
 }


### PR DESCRIPTION
## Context

`ghtkn` obtains a GitHub App User access token via the OAuth **Device Flow**, which is interactive: it prints a one-time (user) code and waits for the user. A coding agent (or any background / non-interactive process) cannot complete this, so it would block indefinitely.

This PR adds an opt-out so such callers fail fast with an actionable error instead of blocking, and exposes that error so callers can detect it.

## Example

~/.claude/settings.json:

```json
{
  "env": {
    "GHTKN_DISABLE_DEVICE_FLOW": "true"
  }
}
```

Claude Code asks me to run `ghtkn get` expectedly.

```console
❯ claude
▗ ▗   ▖ ▖  Claude Code v2.1.158
           Opus 4.8 (1M context) with high effort · Claude Max
  ▘▘ ▝▝    ~/repos/src/github.com/csm-actions/securefix-action

   Opus 4.8 is here! Now defaults to high effort · /effort xhigh for your hardest tasks

❯ gh repo view                                                                                                                                

⏺ Bash(gh repo view)
  ⎿  Error: Exit code 1
     May 31 14:27:42.175 ERR ghtkn failed program=ghtkn version=v3.0.0-local error="get or create access token: get or create token: create a
     GitHub App User Access Token: a GitHub App User access token can't be created via Device Flow because it's disabled by 
     GHTKN_DISABLE_DEVICE_FLOW. The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a
     coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn get` in their own 
     interactive terminal to authenticate"

⏺ gh repo view failed — it couldn't authenticate. The gh CLI here goes through ghtkn, which needs an interactive GitHub App user access token
  (Device Flow is disabled for non-interactive processes).

  Could you authenticate in your own terminal by typing:

  ! ghtkn get

  Once that succeeds, I'll re-run gh repo view.

```

## Change (composed from the base→head diff)

### `ghtkn/internal/api/get.go`
`createToken` checks the environment first; when `GHTKN_DISABLE_DEVICE_FLOW == "true"` it returns `ErrDisableDeviceFlow` without starting the Device Flow:

```go
func (tm *TokenManager) createToken(ctx context.Context, logger *slog.Logger, clientID string) (*pubkeyring.AccessToken, error) {
    if tm.input.Getenv("GHTKN_DISABLE_DEVICE_FLOW") == "true" {
        return nil, pubapi.ErrDisableDeviceFlow
    }
    ...
}
```

The env is read via `tm.input.Getenv`, which production wiring sets to `os.Getenv` in `NewInput`.

### `ghtkn/api/api.go`
New exported sentinel `ErrDisableDeviceFlow` in the public `ghtkn/api` package, with an actionable, agent-aware message:

> a GitHub App User access token can't be created via Device Flow because it's disabled by GHTKN_DISABLE_DEVICE_FLOW. The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn get` in their own interactive terminal to authenticate

The message deliberately tells a coding agent **not** to re-run `ghtkn get` itself (it would fail again in the background) but to ask the user to run it in an interactive terminal. (The leading character is lowercase to satisfy staticcheck ST1005, since the error is wrapped up the call chain.)

### `ghtkn/client.go`
Re-export from the facade so callers can detect the case without importing `ghtkn/api`:

```go
var ErrDisableDeviceFlow = api.ErrDisableDeviceFlow
```

Both `errors.Is(err, ghtkn.ErrDisableDeviceFlow)` and `errors.Is(err, ghtknapi.ErrDisableDeviceFlow)` work.

### `ghtkn/internal/api/helper_internal_test.go`
- `TestController_createToken` now sets `Getenv` in its `Input` (createToken reads the environment; previously `Getenv` was nil and would panic).
- New `TestController_createToken_disableDeviceFlow` covers the `GHTKN_DISABLE_DEVICE_FLOW == "true"` path: `createToken` returns `ErrDisableDeviceFlow` (checked with `errors.Is`) without invoking the Device Flow.

## Verification

- `go build ./...`: OK
- `cmdx t` (`go test ./... -race`): all pass (incl. the new test)
- `cmdx v` / `cmdx l`: vet clean, golangci-lint 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)