### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,13 +1,20 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard into the Go CI workflows.

## Changes

- `.github/workflows/workflow_call_test.yaml`
  - Bump the `go-test-full-workflow` reusable workflow ref from `v5.0.2` to `v6.0.0` (`98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb`).
  - Declare the `TAKUMI_GUARD_BOT_ID` secret (`required: true`) on `on.workflow_call`.
  - Pass the `TAKUMI_GUARD_BOT_ID` secret to the `test` job via a `secrets:` block.
  - Add `id-token: write` to the `test` job's `permissions`.
- `.github/workflows/test.yaml`
  - Pass the `TAKUMI_GUARD_BOT_ID` secret down to the local `./.github/workflows/workflow_call_test.yaml` call.
  - Add `id-token: write` to the calling `test` job's `permissions`.

## Note

The `go-test-full-workflow` reusable workflow was bumped across a major version (`v5.0.2` -> `v6.0.0`). Please review CI for potential breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)