### PR TITLE
feat: show App Name in the one-time code prompt

### DIFF
--- a/ghtkn/deviceflow/types.go
+++ b/ghtkn/deviceflow/types.go
@@ -22,6 +22,9 @@ type InputShow struct {
 	// afterwards. When false, the UI should ask the user to open the URL
 	// themselves instead.
 	OpenBrowser bool
+	// AppName is the GitHub App name shown alongside the one-time code. It is
+	// optional; when empty, the UI omits the App Name line from the message.
+	AppName string
 }
 
 // Browser provides an interface for opening URLs in a web browser.

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -11,6 +11,7 @@ import (
 	pubconfig "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config"
 	pubdeviceflow "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/config"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/log"
 	publog "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/log"
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
@@ -150,7 +151,10 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 		return token, false, nil
 	}
 	// Create access token
-	token, err = tm.createToken(ctx, logger, input.App.ClientID, input.EnableDeviceFlow)
+	token, err = tm.createToken(ctx, logger, &deviceflow.InputCreate{
+		ClientID: input.App.ClientID,
+		AppName:  input.App.Name,
+	}, input.EnableDeviceFlow)
 	if err != nil {
 		return nil, false, fmt.Errorf("create a GitHub App User Access Token: %w", err)
 	}
@@ -159,11 +163,11 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 
 // createToken generates a new GitHub App access token using the OAuth device flow.
 // It returns a keyring.AccessToken with the token details and expiration date.
-func (tm *TokenManager) createToken(ctx context.Context, logger *slog.Logger, clientID string, enableDeviceFlow bool) (*pubapi.AccessToken, error) {
+func (tm *TokenManager) createToken(ctx context.Context, logger *slog.Logger, input *deviceflow.InputCreate, enableDeviceFlow bool) (*pubapi.AccessToken, error) {
 	if !enableDeviceFlow {
 		return nil, pubapi.ErrDisableDeviceFlow
 	}
-	tk, err := tm.input.DeviceFlow.Create(ctx, logger, clientID)
+	tk, err := tm.input.DeviceFlow.Create(ctx, logger, input)
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -20,7 +20,7 @@ type testDeviceFlow struct {
 	err   error
 }
 
-func (m *testDeviceFlow) Create(_ context.Context, logger *slog.Logger, clientID string) (*deviceflow.AccessToken, error) {
+func (m *testDeviceFlow) Create(_ context.Context, logger *slog.Logger, input *deviceflow.InputCreate) (*deviceflow.AccessToken, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -142,7 +142,7 @@ func TestController_createToken(t *testing.T) {
 
 			logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 
-			got, err := tm.createToken(t.Context(), logger, tt.clientID, true)
+			got, err := tm.createToken(t.Context(), logger, &deviceflow.InputCreate{ClientID: tt.clientID}, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -170,7 +170,7 @@ func TestController_createToken_disableDeviceFlow(t *testing.T) {
 	tm := &TokenManager{input: input}
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 
-	got, err := tm.createToken(t.Context(), logger, "test-client-id", false)
+	got, err := tm.createToken(t.Context(), logger, &deviceflow.InputCreate{ClientID: "test-client-id"}, false)
 	if !errors.Is(err, pubapi.ErrDisableDeviceFlow) {
 		t.Errorf("createToken() error = %v, want ErrDisableDeviceFlow", err)
 	}

--- a/ghtkn/internal/api/manager.go
+++ b/ghtkn/internal/api/manager.go
@@ -71,7 +71,7 @@ func (i *Input) Validate() error {
 
 // deviceFlow defines the interface for creating GitHub App access tokens.
 type deviceFlow interface {
-	Create(ctx context.Context, logger *slog.Logger, clientID string) (*deviceflow.AccessToken, error)
+	Create(ctx context.Context, logger *slog.Logger, input *deviceflow.InputCreate) (*deviceflow.AccessToken, error)
 	SetLogger(logger *publog.Logger)
 	SetOnetimeCodeUI(ui pubdeviceflow.OnetimeCodeUI)
 	SetBrowser(browser pubdeviceflow.Browser)

--- a/ghtkn/internal/api/manager_test.go
+++ b/ghtkn/internal/api/manager_test.go
@@ -23,7 +23,7 @@ func (m *mockDeviceFlow) SetOnetimeCodeUI(_ pubdeviceflow.OnetimeCodeUI) {}
 
 func (m *mockDeviceFlow) SetBrowser(_ pubdeviceflow.Browser) {}
 
-func (m *mockDeviceFlow) Create(_ context.Context, logger *slog.Logger, clientID string) (*deviceflow.AccessToken, error) {
+func (m *mockDeviceFlow) Create(_ context.Context, logger *slog.Logger, input *deviceflow.InputCreate) (*deviceflow.AccessToken, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/ghtkn/internal/deviceflow/client_internal_test.go
+++ b/ghtkn/internal/deviceflow/client_internal_test.go
@@ -535,7 +535,7 @@ func TestClient_Create(t *testing.T) { //nolint:gocognit,cyclop,funlen
 
 			logger := slog.New(slog.DiscardHandler)
 
-			got, err := client.Create(t.Context(), logger, tt.clientID)
+			got, err := client.Create(t.Context(), logger, &InputCreate{ClientID: tt.clientID})
 			if err != nil {
 				if !tt.wantErr {
 					t.Fatalf("unexpected error: %v", err)

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -24,15 +24,24 @@ type availabilityChecker interface {
 	Available() bool
 }
 
+// InputCreate holds the parameters for Create.
+type InputCreate struct {
+	// ClientID is the GitHub App's client ID used to start the device flow. Required.
+	ClientID string
+	// AppName is the GitHub App name shown in the one-time code prompt. Optional;
+	// when empty, the App Name line is omitted from the message.
+	AppName string
+}
+
 // Create initiates the OAuth device flow and returns an access token.
 // It displays the verification URL and user code, opens a browser when one is
 // available, and polls for the access token until the user completes authentication.
 // When no browser is available, the user is asked to open the URL themselves.
-func (c *Client) Create(ctx context.Context, logger *slog.Logger, clientID string) (*AccessToken, error) {
-	if clientID == "" {
+func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCreate) (*AccessToken, error) {
+	if input.ClientID == "" {
 		return nil, errors.New("client id is required")
 	}
-	deviceCode, err := c.getDeviceCode(ctx, clientID)
+	deviceCode, err := c.getDeviceCode(ctx, input.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("get device code: %w", err)
 	}
@@ -45,7 +54,10 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, clientID strin
 	}
 
 	deviceCodeExpirationDate := c.input.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
-	if err := c.input.OnetimeCodeUI.Show(ctx, logger, deviceCode, deviceCodeExpirationDate, &pubdeviceflow.InputShow{OpenBrowser: willOpen}); err != nil {
+	if err := c.input.OnetimeCodeUI.Show(ctx, logger, deviceCode, deviceCodeExpirationDate, &pubdeviceflow.InputShow{
+		OpenBrowser: willOpen,
+		AppName:     input.AppName,
+	}); err != nil {
 		return nil, fmt.Errorf("show device code: %w", err)
 	}
 	if willOpen {
@@ -58,7 +70,7 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, clientID strin
 		}
 	}
 
-	token, err := c.pollForAccessToken(ctx, logger, clientID, deviceCode)
+	token, err := c.pollForAccessToken(ctx, logger, input.ClientID, deviceCode)
 	if err != nil {
 		return nil, fmt.Errorf("get access token: %w", err)
 	}

--- a/ghtkn/internal/deviceflow/create_internal_test.go
+++ b/ghtkn/internal/deviceflow/create_internal_test.go
@@ -97,7 +97,7 @@ func TestClient_Create_browser(t *testing.T) {
 				OnetimeCodeUI: newOnetimeCodeUI(strings.NewReader("\n"), &stderr, &mockWaiter{}),
 			}
 
-			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), "test-client-id")
+			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), &InputCreate{ClientID: "test-client-id"})
 			if err != nil {
 				t.Fatalf("Create() error = %v", err)
 			}

--- a/ghtkn/internal/deviceflow/device_ui.go
+++ b/ghtkn/internal/deviceflow/device_ui.go
@@ -40,26 +40,37 @@ func newOnetimeCodeUI(stdin io.Reader, stderr io.Writer, waiter waiter) *simpleO
 // Note that it exits immediately without waiting input if stdin is not a terminal (pipe/redirect).
 // In case of Git Credential Helper stdin is not a terminal, so it exits immediately.
 func (d *simpleOnetimeCodeUI) Show(ctx context.Context, _ *slog.Logger, deviceCode *pubdeviceflow.DeviceCodeResponse, expirationDate time.Time, input *pubdeviceflow.InputShow) error {
+	msgHeader := `The application uses the device flow to generate your GitHub User Access Token.
+Copy your one-time code: %s
+`
+	if input.AppName != "" {
+		msgHeader += `App Name: %s
+`
+	}
+	msgHeader += `This code is valid until %s
+`
+	// Build the format arguments to match the verbs in msgHeader. The App Name
+	// line (and its verb) is only present when AppName is set, so AppName must be
+	// omitted from the arguments otherwise to keep verbs and arguments aligned.
+	args := []any{deviceCode.UserCode}
+	if input.AppName != "" {
+		args = append(args, input.AppName)
+	}
+	args = append(args, expirationDate.Format(time.RFC3339), deviceCode.VerificationURI)
 	if !input.OpenBrowser {
 		// The browser won't be opened automatically (disabled, or no browser is
 		// available), so ask the user to open the URL themselves. Polling proceeds
 		// immediately; there is nothing to wait for.
-		const msgTemplate = `The application uses the device flow to generate your GitHub User Access Token.
-Copy your one-time code: %s
-This code is valid until %s
-Open the following URL in your browser and enter the one-time code above:
+		msgTemplate := msgHeader + `Open the following URL in your browser and enter the one-time code above:
 %s
 `
-		fmt.Fprintf(d.stderr, msgTemplate, deviceCode.UserCode, expirationDate.Format(time.RFC3339), deviceCode.VerificationURI) //nolint:errcheck
+		fmt.Fprintf(d.stderr, msgTemplate, args...) //nolint:errcheck
 		return nil
 	}
 	if term.IsTerminal(0) {
-		const msgTemplate = `The application uses the device flow to generate your GitHub User Access Token.
-Copy your one-time code: %s
-This code is valid until %s
-Press Enter to open %s in your browser (it opens automatically after 10 seconds)...
+		msgTemplate := msgHeader + `Press Enter to open %s in your browser (it opens automatically after 10 seconds)...
 `
-		fmt.Fprintf(d.stderr, msgTemplate, deviceCode.UserCode, expirationDate.Format(time.RFC3339), deviceCode.VerificationURI) //nolint:errcheck
+		fmt.Fprintf(d.stderr, msgTemplate, args...) //nolint:errcheck
 		inputCh := make(chan error, 1)
 		go func() {
 			// Wait until Enter is pressed
@@ -79,12 +90,9 @@ Press Enter to open %s in your browser (it opens automatically after 10 seconds)
 			return nil
 		}
 	}
-	const msgTemplate = `The application uses the device flow to generate your GitHub User Access Token.
-Copy your one-time code: %s
-This code is valid until %s
-%s will open automatically after a few seconds...
+	msgTemplate := msgHeader + `%s will open automatically after a few seconds...
 `
-	fmt.Fprintf(d.stderr, msgTemplate, deviceCode.UserCode, expirationDate.Format(time.RFC3339), deviceCode.VerificationURI) //nolint:errcheck
+	fmt.Fprintf(d.stderr, msgTemplate, args...) //nolint:errcheck
 	// If stdin is not a terminal, we cannot wait for user input.
 	// So, we just wait for a few seconds to show the message and return.
 	// In case of Git Credential Helper stdin is not a terminal.

--- a/ghtkn/internal/deviceflow/device_ui_internal_test.go
+++ b/ghtkn/internal/deviceflow/device_ui_internal_test.go
@@ -1,0 +1,82 @@
+package deviceflow
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	pubdeviceflow "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
+)
+
+func TestSimpleOnetimeCodeUI_Show(t *testing.T) {
+	t.Parallel()
+
+	deviceCode := &pubdeviceflow.DeviceCodeResponse{
+		UserCode:        "ABCD-1234",
+		VerificationURI: "https://github.com/login/device",
+	}
+	expirationDate := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	expiration := expirationDate.Format(time.RFC3339)
+
+	tests := []struct {
+		name        string
+		appName     string
+		wantContain []string
+		wantExclude []string
+	}{
+		{
+			name:    "without app name",
+			appName: "",
+			wantContain: []string{
+				"Copy your one-time code: ABCD-1234",
+				"This code is valid until " + expiration,
+				deviceCode.VerificationURI,
+			},
+			wantExclude: []string{
+				"App Name:",
+				"%!", // no leftover/EXTRA format args
+			},
+		},
+		{
+			name:    "with app name",
+			appName: "my-app",
+			wantContain: []string{
+				"Copy your one-time code: ABCD-1234",
+				"App Name: my-app",
+				"This code is valid until " + expiration,
+				deviceCode.VerificationURI,
+			},
+			wantExclude: []string{
+				"%!",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stderr := &bytes.Buffer{}
+			ui := newOnetimeCodeUI(strings.NewReader(""), stderr, &mockWaiter{})
+			// OpenBrowser:false takes the deterministic branch that does not depend
+			// on whether stdin is a terminal.
+			if err := ui.Show(t.Context(), slog.New(slog.DiscardHandler), deviceCode, expirationDate, &pubdeviceflow.InputShow{
+				OpenBrowser: false,
+				AppName:     tt.appName,
+			}); err != nil {
+				t.Fatalf("Show() error = %v", err)
+			}
+			got := stderr.String()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\noutput:\n%s", want, got)
+				}
+			}
+			for _, exclude := range tt.wantExclude {
+				if strings.Contains(got, exclude) {
+					t.Errorf("output unexpectedly contains %q\noutput:\n%s", exclude, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Display the GitHub App name in the device flow one-time code message so users can tell which app they are authenticating with when prompted to enter the one-time code.

The App name is **optional** to preserve backward compatibility: when it is empty, the App Name line is omitted from the message entirely.

## Context

When a user authenticates via the OAuth device flow, the CLI prints a message asking them to copy a one-time code and open a verification URL. Previously this message did not indicate which GitHub App the code belongs to. This PR adds an `App Name:` line so the prompt is self-explanatory, while keeping the existing behavior intact for callers that do not supply a name.

## Changes

### Thread the App name through the device flow

- `ghtkn/internal/deviceflow/create.go`: introduce an `InputCreate` struct (`ClientID`, `AppName`) and change `Client.Create` to take `*InputCreate` instead of a bare `clientID string`. The `AppName` is forwarded to the UI via `InputShow`.
- `ghtkn/internal/api/manager.go`: update the `deviceFlow` interface's `Create` signature accordingly.
- `ghtkn/internal/api/get.go`: `createToken` now takes `*deviceflow.InputCreate`, and `getOrCreateToken` populates it with `App.ClientID` and `App.Name`.

### Public API

- `ghtkn/deviceflow/types.go`: add an optional `AppName` field (with doc comment) to the public `InputShow` struct. This is an additive, backward-compatible change for anyone implementing `OnetimeCodeUI`.

### Render the App Name line

- `ghtkn/internal/deviceflow/device_ui.go`: build a shared message header that includes the `App Name: %s` line only when `AppName` is non-empty, and assemble the `fmt.Fprintf` arguments to match the verbs present in the header. This avoids a verb/argument mismatch (which would otherwise corrupt the output and emit `%!(EXTRA ...)`) when no App name is provided.

### Tests

- Add `ghtkn/internal/deviceflow/device_ui_internal_test.go` covering both the empty and non-empty `AppName` cases, asserting the rendered message contains the expected lines and never contains leftover format directives.
- Update existing tests in the `api` and `deviceflow` packages to the new `Create`/`createToken` signatures.

## Verification

- `go build ./...`, `go vet ./...`
- `cmdx v` and `cmdx t` (lint + full test suite) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)