### PR TITLE
feat: support skipping account picker

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -18,10 +18,6 @@ type InputGet struct {
 	// new token. nil means "not specified", in which case the GHTKN_ENABLE_DEVICE_FLOW
 	// environment variable decides (default enabled; set it to "false" to disable).
 	EnableDeviceFlow *bool
-	// SkipAccountPicker overrides whether the GitHub Device Flow account picker is
-	// skipped. nil means "not specified", in which case GHTKN_SKIP_ACCOUNT_PICKER
-	// decides (default disabled; set it to "true" to enable).
-	SkipAccountPicker *bool
 }
 
 // InputRevoke contains the input parameters for revoking access tokens.

--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -18,6 +18,10 @@ type InputGet struct {
 	// new token. nil means "not specified", in which case the GHTKN_ENABLE_DEVICE_FLOW
 	// environment variable decides (default enabled; set it to "false" to disable).
 	EnableDeviceFlow *bool
+	// SkipAccountPicker overrides whether the GitHub Device Flow account picker is
+	// skipped. nil means "not specified", in which case GHTKN_SKIP_ACCOUNT_PICKER
+	// decides (default disabled; set it to "true" to enable).
+	SkipAccountPicker *bool
 }
 
 // ErrDisableDeviceFlow is returned when a new GitHub App access token is needed

--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -13,6 +13,11 @@ import (
 // It contains settings a list of GitHub Apps.
 type Config struct {
 	Apps []*App `json:"apps"`
+	// SkipAccountPicker skips the GitHub Device Flow account picker by appending
+	// GitHub's unofficial skip_account_picker query parameter to the verification
+	// URL. nil means "not specified" and defaults to true (the picker is skipped);
+	// set it to false to show the account picker.
+	SkipAccountPicker *bool `json:"skip_account_picker,omitempty" yaml:"skip_account_picker"`
 }
 
 // Validate checks if the Config is valid.

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -90,7 +90,7 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 		MinExpiration:     input.MinExpiration,
 		App:               app,
 		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
-		SkipAccountPicker: skipAccountPicker(input.SkipAccountPicker, tm.input.Getenv),
+		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get or create token: %w", attrs.With(err))
@@ -134,13 +134,13 @@ func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
 }
 
 // skipAccountPicker resolves whether the GitHub Device Flow account picker is
-// skipped. An explicit override takes precedence; otherwise the
-// GHTKN_SKIP_ACCOUNT_PICKER environment variable enables it when set to "true".
-func skipAccountPicker(override *bool, getEnv func(string) string) bool {
-	if override != nil {
-		return *override
+// skipped from the config value. nil means "not specified" and defaults to true
+// (the picker is skipped); set it to false to show the account picker.
+func skipAccountPicker(cfg *bool) bool {
+	if cfg != nil {
+		return *cfg
 	}
-	return getEnv("GHTKN_SKIP_ACCOUNT_PICKER") == "true"
+	return true
 }
 
 // getOrCreateToken retrieves an existing token from the keyring or creates a new one.

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -93,9 +93,10 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 	)
 
 	token, changed, err := tm.getOrCreateToken(ctx, logger, &inputGetOrCreateToken{
-		MinExpiration:    input.MinExpiration,
-		App:              app,
-		EnableDeviceFlow: enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
+		MinExpiration:     input.MinExpiration,
+		App:               app,
+		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
+		SkipAccountPicker: skipAccountPicker(input.SkipAccountPicker, tm.input.Getenv),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get or create token: %w", attrs.With(err))
@@ -122,9 +123,10 @@ var errStoreToken = errors.New("could not store the token in keyring")
 // It encapsulates the app configuration and expiration requirements
 // used internally by the getOrCreateToken function.
 type inputGetOrCreateToken struct {
-	App              *pubconfig.App // App configuration containing client ID and other settings
-	MinExpiration    time.Duration  // Minimum time before expiration to consider token valid
-	EnableDeviceFlow bool           // Whether the device flow may run to create a new token
+	App               *pubconfig.App // App configuration containing client ID and other settings
+	MinExpiration     time.Duration  // Minimum time before expiration to consider token valid
+	EnableDeviceFlow  bool           // Whether the device flow may run to create a new token
+	SkipAccountPicker bool           // Whether the GitHub account picker should be skipped
 }
 
 // enableDeviceFlow resolves whether the device flow may run. An explicit override
@@ -135,6 +137,16 @@ func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
 		return *override
 	}
 	return getEnv("GHTKN_ENABLE_DEVICE_FLOW") != "false"
+}
+
+// skipAccountPicker resolves whether the GitHub Device Flow account picker is
+// skipped. An explicit override takes precedence; otherwise the
+// GHTKN_SKIP_ACCOUNT_PICKER environment variable enables it when set to "true".
+func skipAccountPicker(override *bool, getEnv func(string) string) bool {
+	if override != nil {
+		return *override
+	}
+	return getEnv("GHTKN_SKIP_ACCOUNT_PICKER") == "true"
 }
 
 // getOrCreateToken retrieves an existing token from the keyring or creates a new one.
@@ -152,8 +164,9 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 	}
 	// Create access token
 	token, err = tm.createToken(ctx, logger, &deviceflow.InputCreate{
-		ClientID: input.App.ClientID,
-		AppName:  input.App.Name,
+		ClientID:          input.App.ClientID,
+		AppName:           input.App.Name,
+		SkipAccountPicker: input.SkipAccountPicker,
 	}, input.EnableDeviceFlow)
 	if err != nil {
 		return nil, false, fmt.Errorf("create a GitHub App User Access Token: %w", err)

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -209,3 +209,34 @@ func TestEnableDeviceFlow(t *testing.T) {
 		})
 	}
 }
+
+func TestSkipAccountPicker(t *testing.T) {
+	t.Parallel()
+	ptr := func(b bool) *bool { return &b }
+	data := []struct {
+		name     string
+		override *bool
+		env      string
+		want     bool
+	}{
+		{name: "default disabled when unset", override: nil, env: "", want: false},
+		{name: "env true enables", override: nil, env: "true", want: true},
+		{name: "env false disables", override: nil, env: "false", want: false},
+		{name: "override true beats env false", override: ptr(true), env: "false", want: true},
+		{name: "override false beats env true", override: ptr(false), env: "true", want: false},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			getEnv := func(k string) string {
+				if k == "GHTKN_SKIP_ACCOUNT_PICKER" {
+					return d.env
+				}
+				return ""
+			}
+			if got := skipAccountPicker(d.override, getEnv); got != d.want {
+				t.Errorf("skipAccountPicker = %v, want %v", got, d.want)
+			}
+		})
+	}
+}

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -214,27 +214,18 @@ func TestSkipAccountPicker(t *testing.T) {
 	t.Parallel()
 	ptr := func(b bool) *bool { return &b }
 	data := []struct {
-		name     string
-		override *bool
-		env      string
-		want     bool
+		name string
+		cfg  *bool
+		want bool
 	}{
-		{name: "default disabled when unset", override: nil, env: "", want: false},
-		{name: "env true enables", override: nil, env: "true", want: true},
-		{name: "env false disables", override: nil, env: "false", want: false},
-		{name: "override true beats env false", override: ptr(true), env: "false", want: true},
-		{name: "override false beats env true", override: ptr(false), env: "true", want: false},
+		{name: "default skipped when unset", cfg: nil, want: true},
+		{name: "explicit true skips", cfg: ptr(true), want: true},
+		{name: "explicit false shows picker", cfg: ptr(false), want: false},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			getEnv := func(k string) string {
-				if k == "GHTKN_SKIP_ACCOUNT_PICKER" {
-					return d.env
-				}
-				return ""
-			}
-			if got := skipAccountPicker(d.override, getEnv); got != d.want {
+			if got := skipAccountPicker(d.cfg); got != d.want {
 				t.Errorf("skipAccountPicker = %v, want %v", got, d.want)
 			}
 		})

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/browser"
@@ -31,6 +32,9 @@ type InputCreate struct {
 	// AppName is the GitHub App name shown in the one-time code prompt. Optional;
 	// when empty, the App Name line is omitted from the message.
 	AppName string
+	// SkipAccountPicker appends GitHub's unofficial skip_account_picker query
+	// parameter to the verification URL.
+	SkipAccountPicker bool
 }
 
 // Create initiates the OAuth device flow and returns an access token.
@@ -44,6 +48,13 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 	deviceCode, err := c.getDeviceCode(ctx, input.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("get device code: %w", err)
+	}
+	if input.SkipAccountPicker {
+		verificationURI, err := appendSkipAccountPickerParam(deviceCode.VerificationURI)
+		if err != nil {
+			return nil, fmt.Errorf("add skip_account_picker to the verification URL: %w", err)
+		}
+		deviceCode.VerificationURI = verificationURI
 	}
 
 	// Decide up front whether the browser will actually be opened, so the UI can
@@ -80,6 +91,17 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 		AccessToken:    token.AccessToken,
 		ExpirationDate: now.Add(time.Duration(token.ExpiresIn) * time.Second),
 	}, nil
+}
+
+func appendSkipAccountPickerParam(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse verification URL: %w", err)
+	}
+	query := u.Query()
+	query.Set("skip_account_picker", "true")
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 // getDeviceCode requests a device code from GitHub's OAuth device endpoint.

--- a/ghtkn/internal/deviceflow/create_internal_test.go
+++ b/ghtkn/internal/deviceflow/create_internal_test.go
@@ -18,10 +18,12 @@ import (
 // availabilityChecker interface, so the device flow treats it as "available".
 type recordingBrowser struct {
 	opened bool
+	url    string
 }
 
-func (b *recordingBrowser) Open(_ context.Context, _ *slog.Logger, _ string) error {
+func (b *recordingBrowser) Open(_ context.Context, _ *slog.Logger, rawURL string) error {
 	b.opened = true
+	b.url = rawURL
 	return nil
 }
 
@@ -59,22 +61,34 @@ func TestClient_Create_browser(t *testing.T) {
 	const manualMsg = "Open the following URL in your browser"
 
 	tests := []struct {
-		name       string
-		setup      func() (pubdeviceflow.Browser, *bool) // browser and a pointer to its "opened" flag
-		wantOpened bool
-		wantManual bool // stderr shows the manual-open instruction
+		name              string
+		setup             func() (pubdeviceflow.Browser, *bool, *string) // browser, pointer to opened flag, pointer to recorded URL
+		skipAccountPicker bool
+		wantOpened        bool
+		wantManual        bool   // stderr shows the manual-open instruction
+		wantBrowserURL    string // if non-empty, browser must have opened this exact URL
+		wantStderrURL     string // if non-empty, stderr must contain this URL
 	}{
 		{
-			name:       "available browser is opened",
-			setup:      func() (pubdeviceflow.Browser, *bool) { b := &recordingBrowser{}; return b, &b.opened },
-			wantOpened: true,
-			wantManual: false,
+			name:           "available browser is opened",
+			setup:          func() (pubdeviceflow.Browser, *bool, *string) { b := &recordingBrowser{}; return b, &b.opened, &b.url },
+			wantOpened:     true,
+			wantManual:     false,
+			wantBrowserURL: "https://github.com/login/device",
 		},
 		{
 			name:       "unavailable browser asks the user to open the URL",
-			setup:      func() (pubdeviceflow.Browser, *bool) { b := &unavailableBrowser{}; return b, &b.opened },
+			setup:      func() (pubdeviceflow.Browser, *bool, *string) { b := &unavailableBrowser{}; return b, &b.opened, &b.url },
 			wantOpened: false,
 			wantManual: true,
+		},
+		{
+			name:              "skip_account_picker appended to verification URL",
+			setup:             func() (pubdeviceflow.Browser, *bool, *string) { b := &recordingBrowser{}; return b, &b.opened, &b.url },
+			skipAccountPicker: true,
+			wantOpened:        true,
+			wantBrowserURL:    "https://github.com/login/device?skip_account_picker=true",
+			wantStderrURL:     "https://github.com/login/device?skip_account_picker=true",
 		},
 	}
 
@@ -85,7 +99,7 @@ func TestClient_Create_browser(t *testing.T) {
 			server := httptest.NewServer(successHandler())
 			defer server.Close()
 
-			br, opened := tt.setup()
+			br, opened, browserURL := tt.setup()
 			var stderr strings.Builder
 			input := &Input{
 				HTTPClient:    &http.Client{Transport: &testTransport{server: server, base: http.DefaultTransport}},
@@ -97,7 +111,10 @@ func TestClient_Create_browser(t *testing.T) {
 				OnetimeCodeUI: newOnetimeCodeUI(strings.NewReader("\n"), &stderr, &mockWaiter{}),
 			}
 
-			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), &InputCreate{ClientID: "test-client-id"})
+			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), &InputCreate{
+				ClientID:          "test-client-id",
+				SkipAccountPicker: tt.skipAccountPicker,
+			})
 			if err != nil {
 				t.Fatalf("Create() error = %v", err)
 			}
@@ -109,6 +126,12 @@ func TestClient_Create_browser(t *testing.T) {
 			}
 			if got := strings.Contains(stderr.String(), manualMsg); got != tt.wantManual {
 				t.Errorf("manual-open instruction shown = %v, want %v\nstderr:\n%s", got, tt.wantManual, stderr.String())
+			}
+			if tt.wantBrowserURL != "" && *browserURL != tt.wantBrowserURL {
+				t.Errorf("browser URL = %q, want %q", *browserURL, tt.wantBrowserURL)
+			}
+			if tt.wantStderrURL != "" && !strings.Contains(stderr.String(), tt.wantStderrURL) {
+				t.Errorf("prompt does not contain %q:\n%s", tt.wantStderrURL, stderr.String())
 			}
 		})
 	}

--- a/ghtkn/internal/deviceflow/create_internal_test.go
+++ b/ghtkn/internal/deviceflow/create_internal_test.go
@@ -77,8 +77,11 @@ func TestClient_Create_browser(t *testing.T) {
 			wantBrowserURL: "https://github.com/login/device",
 		},
 		{
-			name:       "unavailable browser asks the user to open the URL",
-			setup:      func() (pubdeviceflow.Browser, *bool, *string) { b := &unavailableBrowser{}; return b, &b.opened, &b.url },
+			name: "unavailable browser asks the user to open the URL",
+			setup: func() (pubdeviceflow.Browser, *bool, *string) {
+				b := &unavailableBrowser{}
+				return b, &b.opened, &b.url
+			},
 			wantOpened: false,
 			wantManual: true,
 		},

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -29,6 +29,9 @@
             "$ref": "#/$defs/App"
           },
           "type": "array"
+        },
+        "skip_account_picker": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- Add `SkipAccountPicker *bool` to the public `InputGet` API
- Resolve `GHTKN_SKIP_ACCOUNT_PICKER=true` in the SDK using the same override/env-var pattern as `EnableDeviceFlow`
- Append GitHub's unofficial `skip_account_picker=true` query parameter to the Device Flow verification URL before it is displayed in the terminal prompt and opened in the browser, keeping both paths consistent

## Related

- Relates to suzuki-shunsuke/ghtkn#448
- ghtkn consumer PR: suzuki-shunsuke/ghtkn#454

## E2E Testing

While this PR is not yet merged, you can test end-to-end using [Go workspaces](https://go.dev/ref/mod#workspaces). The feature branches live in the contributor's forks, so clone from there:

```sh
# 1. Clone from the contributor's forks
git clone https://github.com/toyamagu-2021/ghtkn-go-sdk ~/work/ghtkn-go-sdk
git clone https://github.com/toyamagu-2021/ghtkn        ~/work/ghtkn

# 2. Check out the feature branches
git -C ~/work/ghtkn-go-sdk checkout feat/skip-account-picker
git -C ~/work/ghtkn        checkout feat/skip-account-picker-sdk

# 3. Create a workspace (go.work is picked up automatically — no GOWORK= needed)
cd ~/work/ghtkn
go work init .
go work use ../ghtkn-go-sdk

# 4. Run as usual
go run ./cmd/ghtkn auth --skip-account-picker
```

The verification URL opened in the browser should contain `?skip_account_picker=true`.

## Validation

```sh
cmdx v
go test ./... -race
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)