### PR TITLE
feat: add GHTKN_OPEN_BROWSER to disable automatic browser opening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,16 +65,16 @@ Both commands should pass before committing changes.
 
 ```
 ghtkn-go-sdk/
-├── cmd/           # Command-line tools
-│   └── gen-jsonschema/  # JSON schema generator
-├── ghtkn/         # Core Go packages
-│   ├── api/       # GitHub API client and token management
-│   ├── deviceflow/  # GitHub App token generation
-│   ├── config/    # Configuration management
-│   ├── github/    # GitHub API interaction
-│   ├── keyring/   # Token caching and keyring operations
-│   └── log/       # Logging utilities
-└── json-schema/   # JSON schema definitions
+|-- cmd/           # Command-line tools
+|   `-- gen-jsonschema/  # JSON schema generator
+|-- ghtkn/         # Core Go packages
+|   |-- api/       # GitHub API client and token management
+|   |-- deviceflow/  # GitHub App token generation
+|   |-- config/    # Configuration management
+|   |-- github/    # GitHub API interaction
+|   |-- keyring/   # Token caching and keyring operations
+|   `-- log/       # Logging utilities
+`-- json-schema/   # JSON schema definitions
 ```
 
 ## Package Responsibilities
@@ -168,6 +168,14 @@ The project includes GitHub Actions for:
 ## Configuration
 
 ## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GHTKN_GITHUB_TOKEN` | - | If set, this token is returned as is instead of running the device flow. |
+| `GHTKN_BACKEND` | - | Selects the token storage backend (e.g. `text`). |
+| `GHTKN_ENABLE_DEVICE_FLOW` | enabled | Set to `false` to disable running the device flow to create a new token. |
+| `GHTKN_OPEN_BROWSER` | enabled | Set to `false` to stop the device flow from opening a browser automatically. The verification URL is shown for the user to open manually. This is useful in WSL, containers, and headless Linux environments where `xdg-open` exists on `PATH` but has no usable browser handler, which otherwise produces noisy errors. |
+| `GHTKN_LOG_LEVEL` | `info` | Log level (e.g. `debug`). |
 
 ## Debugging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,15 @@ The project includes GitHub Actions for:
 
 ## Configuration
 
+Disable automatic browser opening for the device flow:
+
+```yaml
+open_browser:
+  enable: false
+```
+
+This is equivalent to `GHTKN_OPEN_BROWSER=false`; the environment variable takes precedence when set.
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -174,7 +183,7 @@ The project includes GitHub Actions for:
 | `GHTKN_GITHUB_TOKEN` | - | If set, this token is returned as is instead of running the device flow. |
 | `GHTKN_BACKEND` | - | Selects the token storage backend (e.g. `text`). |
 | `GHTKN_ENABLE_DEVICE_FLOW` | enabled | Set to `false` to disable running the device flow to create a new token. |
-| `GHTKN_OPEN_BROWSER` | enabled | Set to `false` to stop the device flow from opening a browser automatically. The verification URL is shown for the user to open manually. This is useful in WSL, containers, and headless Linux environments where `xdg-open` exists on `PATH` but has no usable browser handler, which otherwise produces noisy errors. |
+| `GHTKN_OPEN_BROWSER` | enabled | Set to `false` to stop the device flow from opening a browser automatically. The verification URL is shown for the user to open manually. This is useful in WSL, containers, and headless Linux environments where `xdg-open` exists on `PATH` but has no usable browser handler, which otherwise produces noisy errors. The config field `open_browser.enable` does the same; when this environment variable is set it takes precedence over the config. |
 | `GHTKN_LOG_LEVEL` | `info` | Log level (e.g. `debug`). |
 
 ## Debugging

--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -18,6 +18,16 @@ type Config struct {
 	// URL. nil means "not specified" and defaults to true (the picker is skipped);
 	// set it to false to show the account picker.
 	SkipAccountPicker *bool `json:"skip_account_picker,omitempty" yaml:"skip_account_picker"`
+	// OpenBrowser controls whether the device flow opens a browser automatically.
+	OpenBrowser *OpenBrowser `json:"open_browser,omitempty" yaml:"open_browser"`
+}
+
+// OpenBrowser configures automatic browser opening for the device flow.
+type OpenBrowser struct {
+	// Enable toggles automatic browser opening. nil means "not specified" and
+	// defaults to true. The GHTKN_OPEN_BROWSER environment variable, when set,
+	// takes precedence over this value.
+	Enable *bool `json:"enable,omitempty" yaml:"enable"`
 }
 
 // Validate checks if the Config is valid.

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -91,6 +91,7 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 		App:               app,
 		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
 		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
+		OpenBrowser:       openBrowser(tm.input.Getenv),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get or create token: %w", attrs.With(err))
@@ -121,6 +122,7 @@ type inputGetOrCreateToken struct {
 	MinExpiration     time.Duration  // Minimum time before expiration to consider token valid
 	EnableDeviceFlow  bool           // Whether the device flow may run to create a new token
 	SkipAccountPicker bool           // Whether the GitHub account picker should be skipped
+	OpenBrowser       bool           // Whether the device flow may open a browser automatically
 }
 
 // enableDeviceFlow resolves whether the device flow may run. An explicit override
@@ -131,6 +133,14 @@ func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
 		return *override
 	}
 	return getEnv("GHTKN_ENABLE_DEVICE_FLOW") != "false"
+}
+
+// openBrowser resolves whether the device flow may open a browser automatically.
+// It defaults to enabled unless GHTKN_OPEN_BROWSER is set to "false", which lets
+// users in WSL, containers, and headless environments suppress the unreliable
+// browser launch (and its noisy errors) and open the URL manually instead.
+func openBrowser(getEnv func(string) string) bool {
+	return getEnv("GHTKN_OPEN_BROWSER") != "false"
 }
 
 // skipAccountPicker resolves whether the GitHub Device Flow account picker is
@@ -161,6 +171,7 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 		ClientID:          input.App.ClientID,
 		AppName:           input.App.Name,
 		SkipAccountPicker: input.SkipAccountPicker,
+		OpenBrowser:       input.OpenBrowser,
 	}, input.EnableDeviceFlow)
 	if err != nil {
 		return nil, false, fmt.Errorf("create a GitHub App User Access Token: %w", err)

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -91,7 +91,7 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 		App:               app,
 		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
 		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
-		OpenBrowser:       openBrowser(tm.input.Getenv),
+		OpenBrowser:       openBrowser(cfg.OpenBrowser, tm.input.Getenv),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get or create token: %w", attrs.With(err))
@@ -136,11 +136,19 @@ func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
 }
 
 // openBrowser resolves whether the device flow may open a browser automatically.
-// It defaults to enabled unless GHTKN_OPEN_BROWSER is set to "false", which lets
-// users in WSL, containers, and headless environments suppress the unreliable
-// browser launch (and its noisy errors) and open the URL manually instead.
-func openBrowser(getEnv func(string) string) bool {
-	return getEnv("GHTKN_OPEN_BROWSER") != "false"
+// The GHTKN_OPEN_BROWSER environment variable, when set, takes precedence and
+// only "false" disables the open. Otherwise the config's open_browser.enable
+// decides, defaulting to enabled. This lets users in WSL, containers, and
+// headless environments suppress the unreliable browser launch (and its noisy
+// errors) and open the URL manually instead.
+func openBrowser(cfg *pubconfig.OpenBrowser, getEnv func(string) string) bool {
+	if v := getEnv("GHTKN_OPEN_BROWSER"); v != "" {
+		return v != "false"
+	}
+	if cfg != nil && cfg.Enable != nil {
+		return *cfg.Enable
+	}
+	return true
 }
 
 // skipAccountPicker resolves whether the GitHub Device Flow account picker is

--- a/ghtkn/internal/api/get_test.go
+++ b/ghtkn/internal/api/get_test.go
@@ -203,16 +203,22 @@ func TestTokenManager_Get(t *testing.T) {
 
 func TestOpenBrowser(t *testing.T) {
 	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
 	tests := []struct {
 		name string
 		env  string
+		cfg  *pubconfig.OpenBrowser
 		want bool
 	}{
-		{name: "unset defaults to open", env: "", want: true},
-		{name: "false disables opening", env: "false", want: false},
-		{name: "true keeps opening", env: "true", want: true},
-		{name: "FALSE is case-sensitive and keeps opening", env: "FALSE", want: true},
-		{name: "any other value keeps opening", env: "0", want: true},
+		{name: "env unset and config unset defaults to open", env: "", cfg: nil, want: true},
+		{name: "env unset and config disables", env: "", cfg: &pubconfig.OpenBrowser{Enable: boolPtr(false)}, want: false},
+		{name: "env unset and config enables", env: "", cfg: &pubconfig.OpenBrowser{Enable: boolPtr(true)}, want: true},
+		{name: "env unset and config present but unspecified defaults to open", env: "", cfg: &pubconfig.OpenBrowser{}, want: true},
+		{name: "env false disables with config unset", env: "false", cfg: nil, want: false},
+		{name: "env false overrides config enable", env: "false", cfg: &pubconfig.OpenBrowser{Enable: boolPtr(true)}, want: false},
+		{name: "env true overrides config disable", env: "true", cfg: &pubconfig.OpenBrowser{Enable: boolPtr(false)}, want: true},
+		{name: "env FALSE is case-sensitive and keeps opening", env: "FALSE", cfg: nil, want: true},
+		{name: "env any other value keeps opening", env: "0", cfg: nil, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -223,7 +229,7 @@ func TestOpenBrowser(t *testing.T) {
 				}
 				return ""
 			}
-			if got := openBrowser(getEnv); got != tt.want {
+			if got := openBrowser(tt.cfg, getEnv); got != tt.want {
 				t.Errorf("openBrowser() = %v, want %v", got, tt.want)
 			}
 		})

--- a/ghtkn/internal/api/get_test.go
+++ b/ghtkn/internal/api/get_test.go
@@ -200,3 +200,32 @@ func TestTokenManager_Get(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenBrowser(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "unset defaults to open", env: "", want: true},
+		{name: "false disables opening", env: "false", want: false},
+		{name: "true keeps opening", env: "true", want: true},
+		{name: "FALSE is case-sensitive and keeps opening", env: "FALSE", want: true},
+		{name: "any other value keeps opening", env: "0", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			getEnv := func(key string) string {
+				if key == "GHTKN_OPEN_BROWSER" {
+					return tt.env
+				}
+				return ""
+			}
+			if got := openBrowser(getEnv); got != tt.want {
+				t.Errorf("openBrowser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -35,6 +35,10 @@ type InputCreate struct {
 	// SkipAccountPicker appends GitHub's unofficial skip_account_picker query
 	// parameter to the verification URL.
 	SkipAccountPicker bool
+	// OpenBrowser controls whether the verification URL is opened in a browser
+	// automatically. When false, the URL is only shown for the user to open
+	// manually. Even when true, the browser is opened only if one is available.
+	OpenBrowser bool
 }
 
 // Create initiates the OAuth device flow and returns an access token.
@@ -59,10 +63,7 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 
 	// Decide up front whether the browser will actually be opened, so the UI can
 	// show the right instruction and we only attempt an open that can succeed.
-	willOpen := true
-	if ac, ok := c.input.Browser.(availabilityChecker); ok {
-		willOpen = ac.Available()
-	}
+	willOpen := c.isOpenBrowser(input)
 
 	deviceCodeExpirationDate := c.input.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
 	if err := c.input.OnetimeCodeUI.Show(ctx, logger, deviceCode, deviceCodeExpirationDate, &pubdeviceflow.InputShow{
@@ -91,6 +92,16 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 		AccessToken:    token.AccessToken,
 		ExpirationDate: now.Add(time.Duration(token.ExpiresIn) * time.Second),
 	}, nil
+}
+
+func (c *Client) isOpenBrowser(input *InputCreate) bool {
+	if !input.OpenBrowser {
+		return false
+	}
+	if ac, ok := c.input.Browser.(availabilityChecker); ok {
+		return ac.Available()
+	}
+	return true
 }
 
 func appendSkipAccountPickerParam(rawURL string) (string, error) {

--- a/ghtkn/internal/deviceflow/create_internal_test.go
+++ b/ghtkn/internal/deviceflow/create_internal_test.go
@@ -63,6 +63,7 @@ func TestClient_Create_browser(t *testing.T) {
 	tests := []struct {
 		name              string
 		setup             func() (pubdeviceflow.Browser, *bool, *string) // browser, pointer to opened flag, pointer to recorded URL
+		openBrowser       bool
 		skipAccountPicker bool
 		wantOpened        bool
 		wantManual        bool   // stderr shows the manual-open instruction
@@ -72,6 +73,7 @@ func TestClient_Create_browser(t *testing.T) {
 		{
 			name:           "available browser is opened",
 			setup:          func() (pubdeviceflow.Browser, *bool, *string) { b := &recordingBrowser{}; return b, &b.opened, &b.url },
+			openBrowser:    true,
 			wantOpened:     true,
 			wantManual:     false,
 			wantBrowserURL: "https://github.com/login/device",
@@ -82,16 +84,25 @@ func TestClient_Create_browser(t *testing.T) {
 				b := &unavailableBrowser{}
 				return b, &b.opened, &b.url
 			},
-			wantOpened: false,
-			wantManual: true,
+			openBrowser: true,
+			wantOpened:  false,
+			wantManual:  true,
 		},
 		{
 			name:              "skip_account_picker appended to verification URL",
 			setup:             func() (pubdeviceflow.Browser, *bool, *string) { b := &recordingBrowser{}; return b, &b.opened, &b.url },
+			openBrowser:       true,
 			skipAccountPicker: true,
 			wantOpened:        true,
 			wantBrowserURL:    "https://github.com/login/device?skip_account_picker=true",
 			wantStderrURL:     "https://github.com/login/device?skip_account_picker=true",
+		},
+		{
+			name:        "open browser disabled asks the user to open the URL",
+			setup:       func() (pubdeviceflow.Browser, *bool, *string) { b := &recordingBrowser{}; return b, &b.opened, &b.url },
+			openBrowser: false,
+			wantOpened:  false,
+			wantManual:  true,
 		},
 	}
 
@@ -117,6 +128,7 @@ func TestClient_Create_browser(t *testing.T) {
 			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), &InputCreate{
 				ClientID:          "test-client-id",
 				SkipAccountPicker: tt.skipAccountPicker,
+				OpenBrowser:       tt.openBrowser,
 			})
 			if err != nil {
 				t.Fatalf("Create() error = %v", err)

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -32,6 +32,9 @@
         },
         "skip_account_picker": {
           "type": "boolean"
+        },
+        "open_browser": {
+          "$ref": "#/$defs/OpenBrowser"
         }
       },
       "additionalProperties": false,
@@ -39,6 +42,15 @@
       "required": [
         "apps"
       ]
+    },
+    "OpenBrowser": {
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/ghtkn/issues/453

## Why

ghtkn/issues/453 reports that on WSL, containers, and headless Linux environments, `xdg-open` can exist on `PATH` but have no usable browser handler. The device flow then prints noisy errors and a warning log such as:

```
xdg-open: no method available for opening 'https://github.com/login/device'
WRN failed to open the browser ... error="open the browser: exit status 3"
```

The device flow still works because the user can open the URL manually, but the automatic open is unreliable and the output is noisy. The existing `Available()` check only detects whether the opener command exists on `PATH`, so it cannot tell that `xdg-open` will fail at runtime.

Following the maintainer's decision on the issue (option 1), this adds an explicit opt-out rather than embedding WSL-specific browser detection.

## What

Let users disable the automatic browser open through two mechanisms:

- Environment variable `GHTKN_OPEN_BROWSER=false` — a one-off override.
- Config field `open_browser.enable: false` in `ghtkn.yaml` — a persistent setting for environments where the browser open is permanently unusable.

Precedence: when `GHTKN_OPEN_BROWSER` is set it wins (only `false` disables); otherwise `open_browser.enable` decides; when neither is set, opening defaults to enabled, so existing behavior is unchanged. The existing `availabilityChecker` fallback is preserved: even when enabled, the browser is opened only when one is available.

Changes:

- `ghtkn/config/config.go`: add a nested `open_browser` object with an `enable *bool` field, mirroring the existing `*bool` "unspecified" convention used by `skip_account_picker`.
- `ghtkn/internal/api/get.go`: `openBrowser(cfg, getEnv)` resolves env var > config > default, replacing the earlier env-only inline parse. Plumb the result through to the device flow.
- `ghtkn/internal/deviceflow/create.go`: document the `InputCreate.OpenBrowser` field; `isOpenBrowser` short-circuits when it is false.
- `json-schema/ghtkn.json`: regenerated (`cmdx js`) to include the new `open_browser` definition.
- Tests: `TestOpenBrowser` covers the env/config precedence matrix; `TestClient_Create_browser` sets `OpenBrowser` per case and adds a case asserting that a disabled open shows the manual-open instruction.
- `AGENTS.md`: document `GHTKN_OPEN_BROWSER` and the `open_browser.enable` config, and fill in the previously empty Configuration and Environment Variables sections. The directory-tree diagram was converted from box-drawing characters to ASCII so the file passes the repository's ASCII lint check.

End-user documentation lives in the separate CLI repo (`suzuki-shunsuke/ghtkn`) and will be updated there in a follow-up.

## Verification

- `cmdx js` regenerates the schema (committed).
- `cmdx v` (go vet, golangci-lint) passes.
- `cmdx t` passes, including the new and updated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)