### PR TITLE
feat: support revoking all apps' stored tokens and make Revoke best-effort

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -29,7 +29,28 @@ type InputRevoke struct {
 	AppNames []string
 	// ConfigFilePath is the path to the configuration file (auto-detected if empty).
 	ConfigFilePath string
+	// All revokes the stored tokens of every app in the config. When true,
+	// AppNames and the GHTKN_APP / default-app fallback are ignored. This is meant
+	// for incident response: when the environment running ghtkn is compromised, all
+	// stored tokens can be revoked at once.
+	All bool
 }
+
+// Revoke errors are wrapped with one of the following sentinels so callers can
+// tell, via errors.Is, whether a credential might still be live.
+var (
+	// ErrRevoke marks a failure where a token may NOT have been revoked: the
+	// revocation API call failed, or the token could not be read from the backend
+	// to revoke it in the first place. The credential should be treated as still
+	// live and the failure needs attention.
+	ErrRevoke = errors.New("revoke a credential")
+	// ErrBackendCleanup marks a failure to delete an already-revoked token from the
+	// backend. The credential IS revoked (dead); only the backend still holds a
+	// stale copy, so ghtkn may return a revoked token until it is cleaned up. This
+	// is a UX issue, not a security one. errors.Is(err, ErrRevoke) is false for
+	// these, so callers can distinguish them from live-credential failures.
+	ErrBackendCleanup = errors.New("delete a revoked token from the backend")
+)
 
 // ErrDisableDeviceFlow is returned when a new GitHub App access token is needed
 // but the device flow is disabled (GHTKN_ENABLE_DEVICE_FLOW=false). The device flow

--- a/ghtkn/internal/api/revoke.go
+++ b/ghtkn/internal/api/revoke.go
@@ -24,16 +24,46 @@ func (tm *TokenManager) resolveConfigPath(p string) (string, error) {
 	return path, nil
 }
 
+// revokeAppNames resolves which apps' stored tokens Revoke should target.
+//
+//   - input.All: every app in the config (AppNames and the GHTKN_APP / default-app
+//     fallback are ignored).
+//   - input.AppNames given: those apps.
+//   - otherwise: the app selected by GHTKN_APP, then the default app.
+func (tm *TokenManager) revokeAppNames(cfg *pubconfig.Config, input *pubapi.InputRevoke) ([]string, error) {
+	if input.All {
+		names := make([]string, 0, len(cfg.Apps))
+		for _, app := range cfg.Apps {
+			names = append(names, app.Name)
+		}
+		return names, nil
+	}
+	if len(input.AppNames) > 0 {
+		return input.AppNames, nil
+	}
+	app := config.SelectApp(cfg, tm.input.Getenv("GHTKN_APP"), "")
+	if app == nil {
+		return nil, errors.New("app is not found in the config")
+	}
+	return []string{app.Name}, nil
+}
+
 // Revoke revokes GitHub credentials and removes the revoked tokens from the backend.
 //
-// The tokens to revoke are the tokens stored in the backend for each app in
-// input.AppNames. When AppNames is empty, it falls back to the app selected by
-// GHTKN_APP (or the default app).
+// The tokens to revoke are the tokens stored in the backend for the apps selected
+// by input (see revokeAppNames): every app when input.All is set, the apps in
+// input.AppNames, or the GHTKN_APP / default app as a fallback.
 //
 // Reading the backend never triggers the device flow and ignores expiration: a
 // stored token is revoked regardless of whether it has expired. Apps with no
 // stored token are skipped. Tokens read from the backend are deleted from it
 // after they are revoked. When there is nothing to revoke, Revoke is a no-op.
+//
+// Revoke is best-effort: a failure for one app does not stop the others, and all
+// failures are aggregated with errors.Join. Each aggregated error is wrapped with
+// pubapi.ErrRevoke (the credential may still be live) or pubapi.ErrBackendCleanup
+// (the credential is revoked but a stale copy remains in the backend) so callers
+// can tell the two apart with errors.Is.
 func (tm *TokenManager) Revoke(ctx context.Context, logger *slog.Logger, input *pubapi.InputRevoke) error {
 	if input == nil {
 		input = &pubapi.InputRevoke{}
@@ -48,27 +78,28 @@ func (tm *TokenManager) Revoke(ctx context.Context, logger *slog.Logger, input *
 		return err
 	}
 
-	appNames := input.AppNames
-	if len(appNames) == 0 {
-		// No app names given: fall back to GHTKN_APP, then the default app.
-		app := config.SelectApp(cfg, tm.input.Getenv("GHTKN_APP"), "")
-		if app == nil {
-			return errors.New("app is not found in the config")
-		}
-		appNames = []string{app.Name}
+	appNames, err := tm.revokeAppNames(cfg, input)
+	if err != nil {
+		return err
 	}
 
 	tokens := make([]string, 0, len(appNames))
 	// clientIDs of tokens read from the backend, to delete after revocation.
 	var clientIDs []string
+	// errs aggregates per-app failures so one bad app doesn't block the rest.
+	var errs []error
 	for _, name := range appNames {
 		app := config.SelectApp(cfg, name, "")
 		if app == nil {
-			return fmt.Errorf("app is not found in the config: %s", name)
+			// The intended token was not revoked: treat as a live-credential failure.
+			errs = append(errs, fmt.Errorf("app is not found in the config: %s: %w", name, pubapi.ErrRevoke))
+			continue
 		}
 		tk, err := tm.input.Backend.Get(ctx, app.ClientID)
 		if err != nil {
-			return fmt.Errorf("get a stored token from the backend: %w", err)
+			// The token couldn't be read, so it can't be revoked: it may still be live.
+			errs = append(errs, fmt.Errorf("get a stored token from the backend: app_name=%s: %w: %w", app.Name, err, pubapi.ErrRevoke))
+			continue
 		}
 		if tk == nil {
 			// Nothing stored for this app: do nothing for it.
@@ -80,18 +111,22 @@ func (tm *TokenManager) Revoke(ctx context.Context, logger *slog.Logger, input *
 	}
 
 	if len(tokens) == 0 {
-		return nil
+		return errors.Join(errs...)
 	}
 
 	if err := tm.input.Revoker.Revoke(ctx, tokens); err != nil {
-		return fmt.Errorf("revoke credentials: %w", err)
+		// The revocation API call failed: the credentials may still be live, so they
+		// must NOT be deleted from the backend.
+		errs = append(errs, fmt.Errorf("revoke credentials: %w: %w", err, pubapi.ErrRevoke))
+		return errors.Join(errs...)
 	}
 
-	// Remove the revoked tokens from the backend.
+	// Remove the revoked tokens from the backend (best-effort). These tokens are
+	// already revoked, so a failure here is a cleanup/UX issue, not a security one.
 	for _, clientID := range clientIDs {
 		if err := tm.input.Backend.Delete(ctx, clientID); err != nil {
-			return fmt.Errorf("delete a revoked token from the backend: %w", err)
+			errs = append(errs, fmt.Errorf("delete a revoked token from the backend: client_id=%s: %w: %w", clientID, err, pubapi.ErrBackendCleanup))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/ghtkn/internal/api/revoke_test.go
+++ b/ghtkn/internal/api/revoke_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	pubapi "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/api"
+	pubconfig "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/log"
 )
 
@@ -116,6 +117,151 @@ func TestTokenManager_Revoke(t *testing.T) {
 				t.Errorf("revoked tokens mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantDeleted, tt.backend.deleted); diff != "" {
+				t.Errorf("deleted client ids mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// multiConfigReader is a ConfigReader that returns a fixed set of apps.
+type multiConfigReader struct {
+	apps []*pubconfig.App
+}
+
+func (m *multiConfigReader) Read(cfg *pubconfig.Config, _ string) error {
+	cfg.Apps = m.apps
+	return nil
+}
+
+// mapKeyring is a Backend keyed by client ID, with optional per-client Get/Delete
+// errors so partial-failure scenarios can be exercised.
+type mapKeyring struct {
+	tokens  map[string]*pubapi.AccessToken
+	getErr  map[string]error
+	delErr  map[string]error
+	deleted []string
+}
+
+func (m *mapKeyring) Get(_ context.Context, clientID string) (*pubapi.AccessToken, error) {
+	if err := m.getErr[clientID]; err != nil {
+		return nil, err
+	}
+	return m.tokens[clientID], nil
+}
+
+func (m *mapKeyring) Set(_ context.Context, _ string, _ *pubapi.AccessToken) error {
+	return nil
+}
+
+func (m *mapKeyring) Delete(_ context.Context, clientID string) error {
+	if err := m.delErr[clientID]; err != nil {
+		return err
+	}
+	m.deleted = append(m.deleted, clientID)
+	return nil
+}
+
+func TestTokenManager_Revoke_all(t *testing.T) {
+	t.Parallel()
+
+	tok := func(s string) *pubapi.AccessToken {
+		return &pubapi.AccessToken{AccessToken: s}
+	}
+	apps := []*pubconfig.App{
+		{Name: "a", ClientID: "ca"},
+		{Name: "b", ClientID: "cb"},
+		{Name: "c", ClientID: "cc"},
+	}
+
+	tests := []struct {
+		name        string
+		tokens      map[string]*pubapi.AccessToken
+		getErr      map[string]error
+		delErr      map[string]error
+		revokerErr  error
+		wantRevoked [][]string
+		wantDeleted []string
+		// wantLive is whether the error should be classified as a live-credential
+		// failure (ErrRevoke); wantStale for a backend cleanup failure.
+		wantErr   bool
+		wantLive  bool
+		wantStale bool
+	}{
+		{
+			name:        "all apps with a stored token are revoked and deleted",
+			tokens:      map[string]*pubapi.AccessToken{"ca": tok("ta"), "cb": tok("tb"), "cc": tok("tc")},
+			wantRevoked: [][]string{{"ta", "tb", "tc"}},
+			wantDeleted: []string{"ca", "cb", "cc"},
+		},
+		{
+			name:        "apps without a stored token are skipped",
+			tokens:      map[string]*pubapi.AccessToken{"ca": tok("ta"), "cc": tok("tc")},
+			wantRevoked: [][]string{{"ta", "tc"}},
+			wantDeleted: []string{"ca", "cc"},
+		},
+		{
+			name:        "a Get failure does not stop the others (live-credential failure)",
+			tokens:      map[string]*pubapi.AccessToken{"ca": tok("ta"), "cc": tok("tc")},
+			getErr:      map[string]error{"cb": errors.New("get boom")},
+			wantRevoked: [][]string{{"ta", "tc"}},
+			wantDeleted: []string{"ca", "cc"},
+			wantErr:     true,
+			wantLive:    true,
+		},
+		{
+			name:        "a Delete failure does not stop the others (cleanup failure)",
+			tokens:      map[string]*pubapi.AccessToken{"ca": tok("ta"), "cb": tok("tb"), "cc": tok("tc")},
+			delErr:      map[string]error{"cb": errors.New("delete boom")},
+			wantRevoked: [][]string{{"ta", "tb", "tc"}},
+			wantDeleted: []string{"ca", "cc"},
+			wantErr:     true,
+			wantStale:   true,
+		},
+		{
+			name:        "a revoker failure leaves the backend untouched (live-credential failure)",
+			tokens:      map[string]*pubapi.AccessToken{"ca": tok("ta"), "cb": tok("tb"), "cc": tok("tc")},
+			revokerErr:  errors.New("revoke boom"),
+			wantRevoked: [][]string{{"ta", "tb", "tc"}},
+			wantDeleted: nil,
+			wantErr:     true,
+			wantLive:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			revoker := &mockRevoker{err: tt.revokerErr}
+			backend := &mapKeyring{tokens: tt.tokens, getErr: tt.getErr, delErr: tt.delErr}
+			input := &Input{
+				Backend:      backend,
+				Revoker:      revoker,
+				Logger:       log.NewLogger(),
+				ConfigReader: &multiConfigReader{apps: apps},
+				Getenv:       func(string) string { return "" },
+			}
+			tm := New(input)
+			logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+
+			err := tm.Revoke(t.Context(), logger, &pubapi.InputRevoke{All: true, ConfigFilePath: "/path/to/config.yaml"})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error but got nil")
+				}
+				if got := errors.Is(err, pubapi.ErrRevoke); got != tt.wantLive {
+					t.Errorf("errors.Is(err, ErrRevoke) = %v, want %v (err: %v)", got, tt.wantLive, err)
+				}
+				if got := errors.Is(err, pubapi.ErrBackendCleanup); got != tt.wantStale {
+					t.Errorf("errors.Is(err, ErrBackendCleanup) = %v, want %v (err: %v)", got, tt.wantStale, err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.wantRevoked, revoker.revoked); diff != "" {
+				t.Errorf("revoked tokens mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantDeleted, backend.deleted); diff != "" {
 				t.Errorf("deleted client ids mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/ghtkn/internal/api/revoke_test.go
+++ b/ghtkn/internal/api/revoke_test.go
@@ -267,26 +267,3 @@ func TestTokenManager_Revoke_all(t *testing.T) {
 		})
 	}
 }
-
-func TestTokenManager_Revoke_revokerError(t *testing.T) {
-	t.Parallel()
-
-	storedToken := &pubapi.AccessToken{
-		AccessToken:    "stored-tok",
-		ExpirationDate: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
-	}
-	input := &Input{
-		Backend:      &mockKeyring{token: storedToken},
-		Revoker:      &mockRevoker{err: errors.New("boom")},
-		Logger:       log.NewLogger(),
-		ConfigReader: &mockConfigReader{},
-		Getenv:       func(string) string { return "" },
-	}
-	tm := New(input)
-	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
-
-	err := tm.Revoke(t.Context(), logger, &pubapi.InputRevoke{AppNames: []string{"test-app"}, ConfigFilePath: "/path/to/config.yaml"})
-	if err == nil {
-		t.Fatal("expected an error but got nil")
-	}
-}


### PR DESCRIPTION
## Overview

Add support for revoking the stored tokens of every app in the config at once, and make `TokenManager.Revoke` best-effort so a single failure no longer aborts the whole operation.

This is motivated by incident response: when the environment running ghtkn is compromised, the user needs to revoke all stored access tokens immediately.

## Changes

### `InputRevoke.All`

`ghtkn/api/api.go` gains an `All bool` field on `InputRevoke`. When `All` is true, `Revoke` targets every app in the config and ignores both `AppNames` and the `GHTKN_APP` / default-app fallback.

App selection is factored into a new `revokeAppNames` helper with a clear precedence: `All` (all apps) > `AppNames` > `GHTKN_APP` / default app.

### Best-effort revocation

Previously `Revoke` returned on the first error, so one failing app (e.g. a backend read error) prevented the remaining apps from being revoked. It is now best-effort: per-app failures are collected and aggregated with `errors.Join`, and processing continues.

The batch revocation call itself is unchanged — the underlying revoke library sends up to 1000 credentials in a single request, so token revocation remains all-or-nothing. If that call fails, no tokens are deleted from the backend.

### Typed errors

Two sentinel errors let callers distinguish, via `errors.Is`, whether a credential might still be live:

- `ErrRevoke` — the credential may NOT be revoked: the revocation API call failed, or the token could not be read from the backend in the first place. Needs attention; treat the credential as live.
- `ErrBackendCleanup` — the credential IS revoked (dead), but a stale copy remains in the backend because `Delete` failed. ghtkn may return a revoked token until cleanup succeeds. A UX issue, not a security one. `errors.Is(err, ErrRevoke)` is false for these.

## Tests

`ghtkn/internal/api/revoke_test.go` adds `TestTokenManager_Revoke_all` covering:

- `All` revokes every app that has a stored token, and deletes them from the backend.
- Apps without a stored token are skipped.
- A `Backend.Get` failure does not stop the others and is classified as `ErrRevoke`.
- A `Backend.Delete` failure does not stop the others and is classified as `ErrBackendCleanup`.
- A revoker failure leaves the backend untouched and is classified as `ErrRevoke`.

## Follow-up

The ghtkn CLI (`ghtkn revoke --all`) consumes this API. That change is in a separate PR in the `ghtkn` repo and depends on a release of this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
