### PR TITLE
feat!: support min_expiration and device_flow.enable in the config file

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -10,13 +10,19 @@ import (
 // It provides configuration options for specifying which app to use,
 // where to find configuration, and token expiration requirements.
 type InputGet struct {
-	AppName        string        // Name of the app to use (defaults to GHTKN_APP environment variable)
-	ConfigFilePath string        // Path to configuration file (auto-detected if empty)
-	AppOwner       string        // GitHub App Owner
-	MinExpiration  time.Duration // Minimum time before token expiration to trigger renewal
+	AppName        string // Name of the app to use (defaults to GHTKN_APP environment variable)
+	ConfigFilePath string // Path to configuration file (auto-detected if empty)
+	AppOwner       string // GitHub App Owner
+	// MinExpiration overrides the minimum time before token expiration that triggers
+	// renewal. nil means "not specified", in which case the GHTKN_MIN_EXPIRATION
+	// environment variable and then the config's min_expiration decide (default zero:
+	// renew only once the token has actually expired). A non-nil value, including a
+	// pointer to zero, takes precedence.
+	MinExpiration *time.Duration
 	// EnableDeviceFlow overrides whether the OAuth device flow may run to create a
 	// new token. nil means "not specified", in which case the GHTKN_ENABLE_DEVICE_FLOW
-	// environment variable decides (default enabled; set it to "false" to disable).
+	// environment variable and then the config's device_flow.enable decide (default
+	// enabled; set the environment variable to "false" to disable).
 	EnableDeviceFlow *bool
 }
 

--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -20,6 +20,14 @@ type Config struct {
 	SkipAccountPicker *bool `json:"skip_account_picker,omitempty" yaml:"skip_account_picker"`
 	// OpenBrowser controls whether the device flow opens a browser automatically.
 	OpenBrowser *OpenBrowser `json:"open_browser,omitempty" yaml:"open_browser"`
+	// MinExpiration is the minimum time before token expiration that triggers
+	// renewal, as a Go duration string (e.g. "1h", "30m"). Empty means "not
+	// specified" and defaults to zero (renew only once the token has actually
+	// expired). The -min-expiration flag and the GHTKN_MIN_EXPIRATION environment
+	// variable take precedence over this value.
+	MinExpiration string `json:"min_expiration,omitempty" yaml:"min_expiration"`
+	// DeviceFlow configures whether the OAuth device flow may run to create a new token.
+	DeviceFlow *DeviceFlow `json:"device_flow,omitempty" yaml:"device_flow"`
 }
 
 // OpenBrowser configures automatic browser opening for the device flow.
@@ -27,6 +35,15 @@ type OpenBrowser struct {
 	// Enable toggles automatic browser opening. nil means "not specified" and
 	// defaults to true. The GHTKN_OPEN_BROWSER environment variable, when set,
 	// takes precedence over this value.
+	Enable *bool `json:"enable,omitempty" yaml:"enable"`
+}
+
+// DeviceFlow configures whether the OAuth device flow may run to create a new
+// access token.
+type DeviceFlow struct {
+	// Enable toggles whether the device flow may run. nil means "not specified" and
+	// defaults to true. The -device-flow flag and the GHTKN_ENABLE_DEVICE_FLOW
+	// environment variable take precedence over this value.
 	Enable *bool `json:"enable,omitempty" yaml:"enable"`
 }
 

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -80,16 +80,21 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 	attrs := slogerr.NewAttrs(1)
 	logger = attrs.Add(logger, "app_name", app.Name)
 
+	minExpiration, err := resolveMinExpiration(input.MinExpiration, cfg.MinExpiration, tm.input.Getenv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve the min expiration: %w", attrs.With(err))
+	}
+
 	// Debug Log
 	logger.Debug(
 		"getting or creating a GitHub App User Access Token",
-		"min_expiration", input.MinExpiration,
+		"min_expiration", minExpiration,
 	)
 
 	token, changed, err := tm.getOrCreateToken(ctx, logger, &inputGetOrCreateToken{
-		MinExpiration:     input.MinExpiration,
+		MinExpiration:     minExpiration,
 		App:               app,
-		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
+		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, cfg.DeviceFlow, tm.input.Getenv),
 		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
 		OpenBrowser:       openBrowser(cfg.OpenBrowser, tm.input.Getenv),
 	})
@@ -126,13 +131,47 @@ type inputGetOrCreateToken struct {
 }
 
 // enableDeviceFlow resolves whether the device flow may run. An explicit override
-// (e.g. a CLI flag) takes precedence; otherwise the GHTKN_ENABLE_DEVICE_FLOW
-// environment variable decides, defaulting to enabled unless it is set to "false".
-func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
+// (the -device-flow flag) takes precedence; otherwise the GHTKN_ENABLE_DEVICE_FLOW
+// environment variable decides (only "false" disables it), then the config's
+// device_flow.enable, defaulting to enabled.
+func enableDeviceFlow(override *bool, cfg *pubconfig.DeviceFlow, getEnv func(string) string) bool {
 	if override != nil {
 		return *override
 	}
-	return getEnv("GHTKN_ENABLE_DEVICE_FLOW") != "false"
+	if v := getEnv("GHTKN_ENABLE_DEVICE_FLOW"); v != "" {
+		return v != "false"
+	}
+	if cfg != nil && cfg.Enable != nil {
+		return *cfg.Enable
+	}
+	return true
+}
+
+// resolveMinExpiration resolves the minimum time before token expiration that
+// triggers renewal. An explicit override (the -min-expiration flag) takes
+// precedence, including an explicit zero; otherwise the GHTKN_MIN_EXPIRATION
+// environment variable decides, then the config's min_expiration. It defaults to
+// zero (renew only once the token has actually expired). The environment variable
+// and config values are Go duration strings such as "1h" or "30m".
+func resolveMinExpiration(override *time.Duration, cfg string, getEnv func(string) string) (time.Duration, error) {
+	if override != nil {
+		return *override, nil
+	}
+	if v := getEnv("GHTKN_MIN_EXPIRATION"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, fmt.Errorf("parse GHTKN_MIN_EXPIRATION as a duration: %w", slogerr.With(err, "min_expiration", v))
+		}
+		return d, nil
+	}
+	if cfg != "" {
+		d, err := time.ParseDuration(cfg)
+		if err != nil {
+			return 0, fmt.Errorf("parse min_expiration in the config as a duration: %w", slogerr.With(err, "min_expiration", cfg))
+		}
+		return d, nil
+	}
+	return 0, nil
 }
 
 // openBrowser resolves whether the device flow may open a browser automatically.

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	pubapi "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/api"
+	pubconfig "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config"
 	pubdeviceflow "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/deviceflow"
 	publog "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/log"
@@ -186,13 +187,18 @@ func TestEnableDeviceFlow(t *testing.T) {
 		name     string
 		override *bool
 		env      string
+		cfg      *bool // device_flow.enable in the config file
 		want     bool
 	}{
-		{name: "default enabled when unset", override: nil, env: "", want: true},
+		{name: "default enabled when all unset", override: nil, env: "", cfg: nil, want: true},
 		{name: "env false disables", override: nil, env: "false", want: false},
 		{name: "env true enables", override: nil, env: "true", want: true},
 		{name: "override true beats env false", override: ptr(true), env: "false", want: true},
 		{name: "override false beats env true", override: ptr(false), env: "true", want: false},
+		{name: "config false disables when override and env unset", override: nil, env: "", cfg: ptr(false), want: false},
+		{name: "config true enables when override and env unset", override: nil, env: "", cfg: ptr(true), want: true},
+		{name: "env beats config", override: nil, env: "false", cfg: ptr(true), want: false},
+		{name: "override beats config", override: ptr(false), env: "", cfg: ptr(true), want: false},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
@@ -203,8 +209,57 @@ func TestEnableDeviceFlow(t *testing.T) {
 				}
 				return ""
 			}
-			if got := enableDeviceFlow(d.override, getEnv); got != d.want {
+			var cfg *pubconfig.DeviceFlow
+			if d.cfg != nil {
+				cfg = &pubconfig.DeviceFlow{Enable: d.cfg}
+			}
+			if got := enableDeviceFlow(d.override, cfg, getEnv); got != d.want {
 				t.Errorf("enableDeviceFlow = %v, want %v", got, d.want)
+			}
+		})
+	}
+}
+
+func TestResolveMinExpiration(t *testing.T) {
+	t.Parallel()
+	ptr := func(d time.Duration) *time.Duration { return &d }
+	data := []struct {
+		name     string
+		override *time.Duration
+		env      string
+		cfg      string // min_expiration in the config file
+		want     time.Duration
+		wantErr  bool
+	}{
+		{name: "default zero when all unset", want: 0},
+		{name: "override wins", override: ptr(time.Hour), env: "30m", cfg: "10m", want: time.Hour},
+		{name: "override zero beats config", override: ptr(0), env: "", cfg: "1h", want: 0},
+		{name: "env when override unset", env: "30m", cfg: "10m", want: 30 * time.Minute},
+		{name: "config when override and env unset", cfg: "10m", want: 10 * time.Minute},
+		{name: "invalid env errors", env: "nope", wantErr: true},
+		{name: "invalid config errors", cfg: "nope", wantErr: true},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			getEnv := func(k string) string {
+				if k == "GHTKN_MIN_EXPIRATION" {
+					return d.env
+				}
+				return ""
+			}
+			got, err := resolveMinExpiration(d.override, d.cfg, getEnv)
+			if d.wantErr {
+				if err == nil {
+					t.Fatal("resolveMinExpiration: expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveMinExpiration: unexpected error: %v", err)
+			}
+			if got != d.want {
+				t.Errorf("resolveMinExpiration = %v, want %v", got, d.want)
 			}
 		})
 	}

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -35,6 +35,12 @@
         },
         "open_browser": {
           "$ref": "#/$defs/OpenBrowser"
+        },
+        "min_expiration": {
+          "type": "string"
+        },
+        "device_flow": {
+          "$ref": "#/$defs/DeviceFlow"
         }
       },
       "additionalProperties": false,
@@ -42,6 +48,15 @@
       "required": [
         "apps"
       ]
+    },
+    "DeviceFlow": {
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "OpenBrowser": {
       "properties": {


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/ghtkn/issues/467
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

## Overview

Add two configuration-file fields and let the SDK resolve them with a consistent precedence:

- `min_expiration` — the minimum time before token expiration that triggers renewal, as a Go duration string (e.g. `1h`, `30m`).
- `device_flow.enable` — whether the OAuth device flow may run to create a new token. This mirrors the existing `open_browser.enable`.

```yaml
min_expiration: 1h
device_flow:
  enable: false
```

Until now neither knob could be set from the config file: `min_expiration` had no config field at all, and `device_flow.enable` did not exist. This PR adds both and resolves each through a single, consistent order of precedence.

## Precedence

For both fields the order is: explicit override (the CLI flag, passed in via `InputGet`) > environment variable > config file > default.

- device flow: `InputGet.EnableDeviceFlow` > `GHTKN_ENABLE_DEVICE_FLOW` > `device_flow.enable` > default (enabled)
- min expiration: `InputGet.MinExpiration` > `GHTKN_MIN_EXPIRATION` > `min_expiration` > default (zero, i.e. renew only once the token has actually expired)

The environment variables are read inside the SDK so they apply to every SDK consumer, keeping a single source of truth rather than relying on each caller (such as the CLI flags) to read them.

## Changes

- `ghtkn/config/config.go`: add `Config.MinExpiration string`, `Config.DeviceFlow *DeviceFlow`, and the `DeviceFlow` type (`Enable *bool`).
- `ghtkn/internal/api/get.go`:
  - `enableDeviceFlow` now takes the config's `DeviceFlow` and resolves override > env > config > default. Previously the env check `getEnv(...) != "false"` collapsed "unset" and "any non-false value" into enabled, leaving no room for a config fallback.
  - new `resolveMinExpiration` resolves override > env > config > default. Invalid duration strings from the env var or config return a clear error. The debug log now reports the resolved value.
- `ghtkn/api/api.go`: `InputGet.MinExpiration` changes from `time.Duration` to `*time.Duration`.
- `ghtkn/internal/api/helper_internal_test.go`: extend `TestEnableDeviceFlow` with config cases and add `TestResolveMinExpiration`.
- `json-schema/ghtkn.json`: regenerated (`min_expiration` string, `device_flow.enable` boolean).

## Breaking change

`InputGet.MinExpiration` changes from `time.Duration` to `*time.Duration` so an explicit zero (renew only when the token has actually expired) can be distinguished from "not specified". `nil` means "not specified" and lets `GHTKN_MIN_EXPIRATION` and then the config decide; a non-nil pointer, including a pointer to zero, takes precedence.

Migration for SDK consumers: wrap the existing value in a pointer, e.g. `d := 1 * time.Hour; input.MinExpiration = &d`. Leaving the field nil now falls back to the environment variable and config instead of behaving like a zero duration.
