### PR TITLE
feat: support backend.type in the config file

### DIFF
--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	MinExpiration string `json:"min_expiration,omitempty" yaml:"min_expiration"`
 	// DeviceFlow configures whether the OAuth device flow may run to create a new token.
 	DeviceFlow *DeviceFlow `json:"device_flow,omitempty" yaml:"device_flow"`
+	// Backend selects the storage backend for access tokens.
+	Backend *Backend `json:"backend,omitempty" yaml:"backend"`
 }
 
 // OpenBrowser configures automatic browser opening for the device flow.
@@ -45,6 +47,14 @@ type DeviceFlow struct {
 	// defaults to true. The -device-flow flag and the GHTKN_ENABLE_DEVICE_FLOW
 	// environment variable take precedence over this value.
 	Enable *bool `json:"enable,omitempty" yaml:"enable"`
+}
+
+// Backend selects the storage backend for access tokens.
+type Backend struct {
+	// Type is the backend type: "keyring" (the default), "text", or "agent". Empty
+	// means "not specified". The GHTKN_BACKEND environment variable takes precedence
+	// over this value.
+	Type string `json:"type,omitempty" yaml:"type"`
 }
 
 // Validate checks if the Config is valid.

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -85,6 +85,11 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 		return nil, nil, fmt.Errorf("resolve the min expiration: %w", attrs.With(err))
 	}
 
+	b, err := tm.resolveBackend(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve the backend: %w", attrs.With(err))
+	}
+
 	// Debug Log
 	logger.Debug(
 		"getting or creating a GitHub App User Access Token",
@@ -94,6 +99,7 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 	token, changed, err := tm.getOrCreateToken(ctx, logger, &inputGetOrCreateToken{
 		MinExpiration:     minExpiration,
 		App:               app,
+		Backend:           b,
 		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, cfg.DeviceFlow, tm.input.Getenv),
 		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
 		OpenBrowser:       openBrowser(cfg.OpenBrowser, tm.input.Getenv),
@@ -103,8 +109,8 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 	}
 
 	if changed {
-		// Store the token in keyring
-		if err := tm.input.Backend.Set(ctx, app.ClientID, &pubapi.AccessToken{
+		// Store the token in the backend
+		if err := b.Set(ctx, app.ClientID, &pubapi.AccessToken{
 			AccessToken:    token.AccessToken,
 			ExpirationDate: token.ExpirationDate,
 		}); err != nil {
@@ -124,6 +130,7 @@ var errStoreToken = errors.New("could not store the token in keyring")
 // used internally by the getOrCreateToken function.
 type inputGetOrCreateToken struct {
 	App               *pubconfig.App // App configuration containing client ID and other settings
+	Backend           Backend        // Resolved storage backend for reading and writing the token
 	MinExpiration     time.Duration  // Minimum time before expiration to consider token valid
 	EnableDeviceFlow  bool           // Whether the device flow may run to create a new token
 	SkipAccountPicker bool           // Whether the GitHub account picker should be skipped
@@ -145,6 +152,19 @@ func enableDeviceFlow(override *bool, cfg *pubconfig.DeviceFlow, getEnv func(str
 		return *cfg.Enable
 	}
 	return true
+}
+
+// resolveBackendType resolves the storage backend type. The GHTKN_BACKEND
+// environment variable takes precedence, then the config's backend.type. An empty
+// result selects the default (the OS keyring); backend.New maps it accordingly.
+func resolveBackendType(cfg *pubconfig.Backend, getEnv func(string) string) string {
+	if v := getEnv("GHTKN_BACKEND"); v != "" {
+		return v
+	}
+	if cfg != nil && cfg.Type != "" {
+		return cfg.Type
+	}
+	return ""
 }
 
 // resolveMinExpiration resolves the minimum time before token expiration that
@@ -245,8 +265,8 @@ func (tm *TokenManager) createToken(ctx context.Context, logger *slog.Logger, in
 // getAccessTokenFromBackend retrieves a cached access token from the system keyring.
 // It returns nil if the token doesn't exist or has expired based on MinExpiration.
 func (tm *TokenManager) getAccessTokenFromBackend(ctx context.Context, logger *slog.Logger, input *inputGetOrCreateToken) (*pubapi.AccessToken, error) {
-	// Get an access token from keyring
-	tk, err := tm.input.Backend.Get(ctx, input.App.ClientID)
+	// Get an access token from the backend
+	tk, err := input.Backend.Get(ctx, input.App.ClientID)
 	if err != nil {
 		return nil, err
 	}

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -265,6 +265,39 @@ func TestResolveMinExpiration(t *testing.T) {
 	}
 }
 
+func TestResolveBackendType(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name string
+		env  string
+		cfg  string // backend.type in the config file
+		want string
+	}{
+		{name: "default empty when all unset", want: ""},
+		{name: "env wins", env: "agent", cfg: "text", want: "agent"},
+		{name: "config when env unset", env: "", cfg: "text", want: "text"},
+		{name: "env beats config", env: "keyring", cfg: "text", want: "keyring"},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			getEnv := func(k string) string {
+				if k == "GHTKN_BACKEND" {
+					return d.env
+				}
+				return ""
+			}
+			var cfg *pubconfig.Backend
+			if d.cfg != "" {
+				cfg = &pubconfig.Backend{Type: d.cfg}
+			}
+			if got := resolveBackendType(cfg, getEnv); got != d.want {
+				t.Errorf("resolveBackendType = %q, want %q", got, d.want)
+			}
+		})
+	}
+}
+
 func TestSkipAccountPicker(t *testing.T) {
 	t.Parallel()
 	ptr := func(b bool) *bool { return &b }

--- a/ghtkn/internal/api/manager.go
+++ b/ghtkn/internal/api/manager.go
@@ -49,14 +49,13 @@ type Input struct {
 
 // NewInput creates a new Input instance with default production values.
 // It sets up all necessary dependencies including file system, HTTP client, and keyring access.
+//
+// The storage backend is not built here: its type can come from the config file
+// (backend.type), which isn't read until Get/Revoke, so the backend is resolved
+// lazily then. Backend is left nil and built on demand by resolveBackend.
 func NewInput(getEnv func(string) string) (*Input, error) {
-	b, err := backend.New(getEnv("GHTKN_BACKEND"), getEnv)
-	if err != nil {
-		return nil, err
-	}
 	return &Input{
 		DeviceFlow:   deviceflow.NewClient(deviceflow.NewInput()),
-		Backend:      b,
 		Revoker:      revoke.New(nil),
 		Now:          time.Now,
 		Logger:       log.NewLogger(),
@@ -64,6 +63,18 @@ func NewInput(getEnv func(string) string) (*Input, error) {
 		Getenv:       getEnv,
 		GOOS:         runtime.GOOS,
 	}, nil
+}
+
+// resolveBackend returns the storage backend to use. An injected backend
+// (Input.Backend, e.g. set by a test or an SDK consumer) is honored as is.
+// Otherwise the backend is built from the resolved backend type: the
+// GHTKN_BACKEND environment variable takes precedence, then the config's
+// backend.type, defaulting to the OS keyring.
+func (tm *TokenManager) resolveBackend(cfg *pubconfig.Config) (Backend, error) {
+	if tm.input.Backend != nil {
+		return tm.input.Backend, nil
+	}
+	return backend.New(resolveBackendType(cfg.Backend, tm.input.Getenv), tm.input.Getenv)
 }
 
 // Validate checks if the Input configuration is valid.

--- a/ghtkn/internal/api/manager_test.go
+++ b/ghtkn/internal/api/manager_test.go
@@ -56,8 +56,10 @@ func TestNewInput(t *testing.T) {
 		t.Error("NewInput().AppTokenClient is nil")
 	}
 
-	if input.Backend == nil {
-		t.Error("NewInput().Backend is nil")
+	// Backend is built lazily (its type can come from the config file), so NewInput
+	// leaves it nil and resolveBackend builds it on demand in Get/Revoke.
+	if input.Backend != nil {
+		t.Error("NewInput().Backend should be nil; it is resolved lazily")
 	}
 
 	if input.Now == nil {

--- a/ghtkn/internal/api/revoke.go
+++ b/ghtkn/internal/api/revoke.go
@@ -83,6 +83,11 @@ func (tm *TokenManager) Revoke(ctx context.Context, logger *slog.Logger, input *
 		return err
 	}
 
+	b, err := tm.resolveBackend(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve the backend: %w", err)
+	}
+
 	tokens := make([]string, 0, len(appNames))
 	// clientIDs of tokens read from the backend, to delete after revocation.
 	var clientIDs []string
@@ -95,7 +100,7 @@ func (tm *TokenManager) Revoke(ctx context.Context, logger *slog.Logger, input *
 			errs = append(errs, fmt.Errorf("app is not found in the config: %s: %w", name, pubapi.ErrRevoke))
 			continue
 		}
-		tk, err := tm.input.Backend.Get(ctx, app.ClientID)
+		tk, err := b.Get(ctx, app.ClientID)
 		if err != nil {
 			// The token couldn't be read, so it can't be revoked: it may still be live.
 			errs = append(errs, fmt.Errorf("get a stored token from the backend: app_name=%s: %w: %w", app.Name, err, pubapi.ErrRevoke))
@@ -124,7 +129,7 @@ func (tm *TokenManager) Revoke(ctx context.Context, logger *slog.Logger, input *
 	// Remove the revoked tokens from the backend (best-effort). These tokens are
 	// already revoked, so a failure here is a cleanup/UX issue, not a security one.
 	for _, clientID := range clientIDs {
-		if err := tm.input.Backend.Delete(ctx, clientID); err != nil {
+		if err := b.Delete(ctx, clientID); err != nil {
 			errs = append(errs, fmt.Errorf("delete a revoked token from the backend: client_id=%s: %w: %w", clientID, err, pubapi.ErrBackendCleanup))
 		}
 	}

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -22,6 +22,15 @@
         "client_id"
       ]
     },
+    "Backend": {
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Config": {
       "properties": {
         "apps": {
@@ -41,6 +50,9 @@
         },
         "device_flow": {
           "$ref": "#/$defs/DeviceFlow"
+        },
+        "backend": {
+          "$ref": "#/$defs/Backend"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/ghtkn/issues/467
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

## Overview

Let users select the storage backend from the config file, in addition to the existing `GHTKN_BACKEND` environment variable.

```yaml
backend:
  type: agent # text, keyring
```

Precedence: `GHTKN_BACKEND` > config `backend.type` > default (keyring). No CLI flag.

This continues the direction of the recently merged `min_expiration` / `device_flow.enable` work (issue suzuki-shunsuke/ghtkn#467).

## Why this one needs a refactor

`min_expiration` and `device_flow.enable` are resolved at call time inside `Get()`, after the config file is read. The backend was different: it was built eagerly in `NewInput()` (`backend.New(getEnv("GHTKN_BACKEND"), getEnv)`), which runs before any config is read. So letting `backend.type` come from config requires deferring backend construction to the `Get()` / `Revoke()` call paths. The backend constructors (`agent.New`, `text.New`, `keyring.New`) are side-effect-free (they only resolve a socket path / directory), so deferring is safe.

## Changes

- `ghtkn/config/config.go`: add `Config.Backend (*Backend)` with `Type string` (`backend.type`), mirroring the optional-pointer style of `OpenBrowser` / `DeviceFlow`.
- `ghtkn/internal/api/manager.go`: `NewInput` no longer builds the backend; `Input.Backend` is left nil and resolved lazily by `TokenManager.resolveBackend`, which honors an injected backend (tests / SDK consumers) and otherwise builds one from the resolved type.
- `ghtkn/internal/api/get.go`: add `resolveBackendType` (mirrors `enableDeviceFlow`: env > config > default). `Get()` resolves the backend once after reading the config and threads it through (`inputGetOrCreateToken` gains a `Backend` field) instead of reading `tm.input.Backend` directly.
- `ghtkn/internal/api/revoke.go`: resolve the backend once after reading the config and use it for the read/delete.
- Tests: `TestNewInput` no longer asserts an eagerly-built backend; add `TestResolveBackendType` (env > config > default). Existing `get`/`revoke` tests inject `Input.Backend`, which `resolveBackend` honors.
- `json-schema/ghtkn.json`: regenerated with `backend.type`.

## Behavior

An unsupported backend type surfaces a clear error from `backend.New` at call time (same approach as invalid `min_expiration` strings). No public API breakage: the high-level `ghtkn` client is unaffected; only the internal `Input.Backend` is now resolved lazily.
