### PR TITLE
chore: remove afero dependency

### DIFF
--- a/ghtkn/internal/api/manager.go
+++ b/ghtkn/internal/api/manager.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/api"
 	pubconfig "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config"
 	pubdeviceflow "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
@@ -59,7 +58,7 @@ func NewInput(getEnv func(string) string) (*Input, error) {
 		Revoker:      revoke.New(nil),
 		Now:          time.Now,
 		Logger:       log.NewLogger(),
-		ConfigReader: config.NewReader(afero.NewOsFs()),
+		ConfigReader: config.NewReader(),
 		Getenv:       getEnv,
 		GOOS:         runtime.GOOS,
 	}, nil

--- a/ghtkn/internal/config/config.go
+++ b/ghtkn/internal/config/config.go
@@ -5,20 +5,18 @@ package config
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/spf13/afero"
 	pubconfig "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config"
 	"gopkg.in/yaml.v3"
 )
 
 // Reader handles reading configuration files from the filesystem.
-type Reader struct {
-	fs afero.Fs
-}
+type Reader struct{}
 
-// NewReader creates a new configuration Reader with the given filesystem.
-func NewReader(fs afero.Fs) *Reader {
-	return &Reader{fs: fs}
+// NewReader creates a new configuration Reader.
+func NewReader() *Reader {
+	return &Reader{}
 }
 
 // Read reads and parses a configuration file from the given path.
@@ -28,7 +26,7 @@ func (r *Reader) Read(cfg *pubconfig.Config, configFilePath string) error {
 	if configFilePath == "" {
 		return nil
 	}
-	f, err := r.fs.Open(configFilePath)
+	f, err := os.Open(configFilePath)
 	if err != nil {
 		return fmt.Errorf("open a configuration file: %w", err)
 	}

--- a/ghtkn/internal/config/config_test.go
+++ b/ghtkn/internal/config/config_test.go
@@ -1,9 +1,10 @@
 package config_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/spf13/afero"
 	pubconfig "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/config"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/internal/config"
 )
@@ -11,8 +12,7 @@ import (
 func TestNewReader(t *testing.T) {
 	t.Parallel()
 
-	fs := afero.NewMemMapFs()
-	reader := config.NewReader(fs)
+	reader := config.NewReader()
 
 	if reader == nil {
 		t.Error("NewReader() returned nil")
@@ -40,7 +40,7 @@ func TestReader_Read(t *testing.T) { //nolint:funlen
 		},
 		{
 			name:       "valid config file",
-			configPath: "/test/config.yaml",
+			configPath: "config.yaml",
 			configContent: `apps:
   - name: test-app
     client_id: xxx`,
@@ -57,7 +57,7 @@ func TestReader_Read(t *testing.T) { //nolint:funlen
 		},
 		{
 			name:       "multiple apps config",
-			configPath: "/test/config.yaml",
+			configPath: "config.yaml",
 			configContent: `apps:
   - name: app1
     client_id: xxx
@@ -80,13 +80,13 @@ func TestReader_Read(t *testing.T) { //nolint:funlen
 		},
 		{
 			name:       "file does not exist",
-			configPath: "/test/nonexistent.yaml",
+			configPath: "nonexistent.yaml",
 			fileExists: false,
 			wantErr:    true,
 		},
 		{
 			name:       "invalid YAML",
-			configPath: "/test/config.yaml",
+			configPath: "config.yaml",
 			configContent: `invalid yaml:
   - name: test-app
     client_id: xxx
@@ -96,7 +96,7 @@ func TestReader_Read(t *testing.T) { //nolint:funlen
 		},
 		{
 			name:          "empty config file",
-			configPath:    "/test/config.yaml",
+			configPath:    "config.yaml",
 			configContent: `apps: []`,
 			fileExists:    true,
 			expectedConfig: &pubconfig.Config{
@@ -110,18 +110,20 @@ func TestReader_Read(t *testing.T) { //nolint:funlen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fs := afero.NewMemMapFs()
+			configPath := tt.configPath
+			if tt.configPath != "" {
+				configPath = filepath.Join(t.TempDir(), tt.configPath)
+			}
 			if tt.fileExists {
-				err := afero.WriteFile(fs, tt.configPath, []byte(tt.configContent), 0o644)
-				if err != nil {
+				if err := os.WriteFile(configPath, []byte(tt.configContent), 0o600); err != nil {
 					t.Fatalf("Failed to create test file: %v", err)
 				}
 			}
 
-			reader := config.NewReader(fs)
+			reader := config.NewReader()
 			cfg := &pubconfig.Config{}
 
-			err := reader.Read(cfg, tt.configPath)
+			err := reader.Read(cfg, configPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Reader.Read() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.4
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
 	github.com/suzuki-shunsuke/go-exec v0.0.1
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1
@@ -24,5 +23,4 @@ require (
 	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
-	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
-github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -41,8 +39,6 @@ golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
 golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
-golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
-golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Overview

Remove the `github.com/spf13/afero` dependency. It was only used by the internal config `Reader`, which opened a configuration file and read it — a single `fs.Open` call. The filesystem abstraction afero provides was not needed, so this replaces it with the standard library `os` package.

## Changes

- `ghtkn/internal/config/config.go`: Drop the `fs afero.Fs` field from `Reader`. `NewReader()` now takes no arguments, and `Read` calls `os.Open` directly.
- `ghtkn/internal/api/manager.go`: Construct the reader via `config.NewReader()` instead of `config.NewReader(afero.NewOsFs())`.
- `ghtkn/internal/config/config_test.go`: Replace the in-memory `afero` filesystem with real files created under `t.TempDir()` using `os.WriteFile`.
- `go.mod` / `go.sum`: `go mod tidy` removes the direct `afero` dependency and the now-unused transitive `golang.org/x/text` dependency.

All of the affected code is in internal packages, so there is no change to the public API.

## Verification

- `go build ./...`
- `go test ./...`
- `golangci-lint run` (0 issues)
- `go mod tidy` leaves go.mod with afero removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)