### PR TITLE
chore: inline go-exec to remove the dependency

### DIFF
--- a/ghtkn/browser/browser.go
+++ b/ghtkn/browser/browser.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os/exec"
 
-	"github.com/suzuki-shunsuke/go-exec/goexec"
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
 
@@ -52,7 +51,7 @@ func runCmd(ctx context.Context, url string) error {
 		if _, err := exec.LookPath(cmd); err != nil {
 			continue
 		}
-		if err := goexec.Command(ctx, cmd, url).Run(); err != nil {
+		if err := command(ctx, cmd, url).Run(); err != nil {
 			return fmt.Errorf("open the browser: %w", slogerr.With(err, "command_to_open_browser", cmd))
 		}
 		return nil

--- a/ghtkn/browser/exec.go
+++ b/ghtkn/browser/exec.go
@@ -1,0 +1,31 @@
+// This file is copied from github.com/suzuki-shunsuke/go-exec (goexec package),
+// which is MIT licensed and authored by the same author as this repository.
+// https://github.com/suzuki-shunsuke/go-exec
+package browser
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const waitDelay = 1000 * time.Hour
+
+func setCancel(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(os.Interrupt)
+	}
+	cmd.WaitDelay = waitDelay
+}
+
+// command creates a new command with the given context, name, and arguments.
+// It sets useful defaults for stdin, stdout, stderr, and signal handling.
+func command(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	setCancel(cmd)
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.4
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
-	github.com/suzuki-shunsuke/go-exec v0.0.1
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1
 	github.com/suzuki-shunsuke/slog-error v0.2.2
 	github.com/zalando/go-keyring v0.2.8

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
-github.com/suzuki-shunsuke/go-exec v0.0.1 h1:xn/lvYnRQOujUd46ph6f6IT0gVJIC8+3liSZKOjNj44=
-github.com/suzuki-shunsuke/go-exec v0.0.1/go.mod h1:KstSwIiQTKY34wEurUcFyKkaJDogBr5E3xxfdkkzvb0=
 github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1 h1:GY+LRLuKNEbJ7P5H+dyQzO6x0Rl6UyZUhyh67SVMI3A=
 github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1/go.mod h1:fSdXI5Cc71V0VHTytPcDrvPvEFNVX3ZekhHACgYQlkE=
 github.com/suzuki-shunsuke/slog-error v0.2.2 h1:z8rymlIlZcMA+ERnnhVigQ0Q+X0pxKqBfDzSIyGh6vU=


### PR DESCRIPTION
## Overview

Remove the `github.com/suzuki-shunsuke/go-exec` dependency. The browser package only used `goexec.Command` to launch a browser, so this inlines that small helper instead of depending on the whole module.

## Changes

- `ghtkn/browser/exec.go` (new): Copy the `Command` helper (and its `setCancel` / `waitDelay` support) from go-exec, renamed to an unexported `command` since it is now package-internal. Only the subset actually used is copied; the `Runner` and `Pipe` helpers are not. A header comment records the source.
- `ghtkn/browser/browser.go`: Call the local `command` instead of `goexec.Command`, and drop the import.
- `go.mod` / `go.sum`: `go mod tidy` removes the go-exec dependency.

The copied code is MIT licensed and authored by the same author as this repository.

## Verification

- `go build ./...`
- `go test ./ghtkn/browser/...`
- `golangci-lint run` (0 issues)
- `go mod tidy` leaves go.mod with go-exec removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)