### PR TITLE
feat: add an injection point to copy the one-time code to the clipboard

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -24,6 +24,13 @@ type InputGet struct {
 	// environment variable and then the config's device_flow.enable decide (default
 	// enabled; set the environment variable to "false" to disable).
 	EnableDeviceFlow *bool
+	// Clipboard overrides whether the device flow copies the one-time code to the
+	// system clipboard. nil means "not specified", in which case the GHTKN_CLIPBOARD
+	// environment variable and then the config's clipboard.enable decide (default
+	// disabled; set the environment variable to "true" to enable). Copying also
+	// requires the consumer to inject an implementation via
+	// Client.SetCopyOnetimeCodeToClipboard.
+	Clipboard *bool
 }
 
 // InputRevoke contains the input parameters for revoking access tokens.

--- a/ghtkn/client.go
+++ b/ghtkn/client.go
@@ -91,6 +91,11 @@ func (c *Client) SetBrowser(b Browser) {
 	c.tm.SetBrowser(b)
 }
 
+// SetCopyOnetimeCodeToClipboard sets the implementation used to copy the one-time code to the clipboard.
+func (c *Client) SetCopyOnetimeCodeToClipboard(f deviceflow.CopyTextToClipboard) {
+	c.tm.SetCopyOnetimeCodeToClipboard(f)
+}
+
 // GetConfigPath returns the default configuration file path for ghtkn.
 func GetConfigPath() (string, error) {
 	return intconfig.GetPath(os.Getenv, runtime.GOOS)

--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	DeviceFlow *DeviceFlow `json:"device_flow,omitempty" yaml:"device_flow"`
 	// Backend selects the storage backend for access tokens.
 	Backend *Backend `json:"backend,omitempty" yaml:"backend"`
+	// Clipboard configures whether the device flow copies the one-time code to the
+	// system clipboard.
+	Clipboard *Clipboard `json:"clipboard,omitempty" yaml:"clipboard"`
 }
 
 // OpenBrowser configures automatic browser opening for the device flow.
@@ -45,6 +48,15 @@ type OpenBrowser struct {
 type DeviceFlow struct {
 	// Enable toggles whether the device flow may run. nil means "not specified" and
 	// defaults to true. The -device-flow flag and the GHTKN_ENABLE_DEVICE_FLOW
+	// environment variable take precedence over this value.
+	Enable *bool `json:"enable,omitempty" yaml:"enable"`
+}
+
+// Clipboard configures whether the device flow copies the one-time code to the
+// system clipboard.
+type Clipboard struct {
+	// Enable toggles copying the one-time code to the clipboard. nil means "not
+	// specified" and defaults to false. The -clipboard flag and the GHTKN_CLIPBOARD
 	// environment variable take precedence over this value.
 	Enable *bool `json:"enable,omitempty" yaml:"enable"`
 }

--- a/ghtkn/deviceflow/types.go
+++ b/ghtkn/deviceflow/types.go
@@ -25,7 +25,18 @@ type InputShow struct {
 	// AppName is the GitHub App name shown alongside the one-time code. It is
 	// optional; when empty, the UI omits the App Name line from the message.
 	AppName string
+	// CopiedToClipboard reports whether the one-time code was successfully copied
+	// to the system clipboard. When true, the UI shows a line telling the user the
+	// code is already on their clipboard.
+	CopiedToClipboard bool
 }
+
+// CopyTextToClipboard copies the given text (the device flow one-time code) to the
+// system clipboard. The SDK does not provide an implementation: consumers inject one
+// via Client.SetCopyOnetimeCodeToClipboard so the clipboard dependency stays out of
+// the SDK module. It returns an error if the copy fails; the caller logs a warning
+// and continues so authentication still succeeds.
+type CopyTextToClipboard func(ctx context.Context, code string) error
 
 // Browser provides an interface for opening URLs in a web browser.
 // This is used to open the GitHub verification URL during device flow authentication.

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -109,6 +109,7 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, cfg.DeviceFlow, tm.input.Getenv),
 		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
 		OpenBrowser:       openBrowser(cfg.OpenBrowser, tm.input.Getenv),
+		Clipboard:         clipboard(input.Clipboard, cfg.Clipboard, tm.input.Getenv),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get or create token: %w", attrs.With(err))
@@ -141,6 +142,7 @@ type inputGetOrCreateToken struct {
 	EnableDeviceFlow  bool           // Whether the device flow may run to create a new token
 	SkipAccountPicker bool           // Whether the GitHub account picker should be skipped
 	OpenBrowser       bool           // Whether the device flow may open a browser automatically
+	Clipboard         bool           // Whether the device flow copies the one-time code to the clipboard
 }
 
 // enableDeviceFlow resolves whether the device flow may run. An explicit override
@@ -216,6 +218,24 @@ func openBrowser(cfg *pubconfig.OpenBrowser, getEnv func(string) string) bool {
 	return true
 }
 
+// clipboard resolves whether the device flow copies the one-time code to the
+// system clipboard. An explicit override (the -clipboard flag) takes precedence;
+// otherwise the GHTKN_CLIPBOARD environment variable decides (only "true" enables
+// it), then the config's clipboard.enable, defaulting to disabled. Copying also
+// requires the consumer to inject an implementation via SetCopyOnetimeCodeToClipboard.
+func clipboard(override *bool, cfg *pubconfig.Clipboard, getEnv func(string) string) bool {
+	if override != nil {
+		return *override
+	}
+	if v := getEnv("GHTKN_CLIPBOARD"); v != "" {
+		return v == "true"
+	}
+	if cfg != nil && cfg.Enable != nil {
+		return *cfg.Enable
+	}
+	return false
+}
+
 // skipAccountPicker resolves whether the GitHub Device Flow account picker is
 // skipped from the config value. nil means "not specified" and defaults to true
 // (the picker is skipped); set it to false to show the account picker.
@@ -245,6 +265,7 @@ func (tm *TokenManager) getOrCreateToken(ctx context.Context, logger *slog.Logge
 		AppName:           input.App.Name,
 		SkipAccountPicker: input.SkipAccountPicker,
 		OpenBrowser:       input.OpenBrowser,
+		Clipboard:         input.Clipboard,
 	}, input.EnableDeviceFlow)
 	if err != nil {
 		return nil, false, fmt.Errorf("create a GitHub App User Access Token: %w", err)

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -37,6 +37,12 @@ func (tm *TokenManager) SetBrowser(ui pubdeviceflow.Browser) {
 	tm.input.DeviceFlow.SetBrowser(ui)
 }
 
+// SetCopyOnetimeCodeToClipboard updates the clipboard implementation used to copy the one-time code.
+// This allows customization of how the one-time code is copied to the user's clipboard.
+func (tm *TokenManager) SetCopyOnetimeCodeToClipboard(f pubdeviceflow.CopyTextToClipboard) {
+	tm.input.DeviceFlow.SetCopyOnetimeCodeToClipboard(f)
+}
+
 // Get executes the main logic for retrieving a GitHub App access token.
 // It checks for cached tokens and creates new tokens if needed.
 //

--- a/ghtkn/internal/api/get_test.go
+++ b/ghtkn/internal/api/get_test.go
@@ -235,3 +235,41 @@ func TestOpenBrowser(t *testing.T) {
 		})
 	}
 }
+
+func TestClipboard(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
+	tests := []struct {
+		name     string
+		override *bool
+		env      string
+		cfg      *pubconfig.Clipboard
+		want     bool
+	}{
+		{name: "all unset defaults to disabled", want: false},
+		{name: "config enables", cfg: &pubconfig.Clipboard{Enable: boolPtr(true)}, want: true},
+		{name: "config disables", cfg: &pubconfig.Clipboard{Enable: boolPtr(false)}, want: false},
+		{name: "config present but unspecified defaults to disabled", cfg: &pubconfig.Clipboard{}, want: false},
+		{name: "env true enables with config unset", env: "true", want: true},
+		{name: "env true overrides config disable", env: "true", cfg: &pubconfig.Clipboard{Enable: boolPtr(false)}, want: true},
+		{name: "env false overrides config enable", env: "false", cfg: &pubconfig.Clipboard{Enable: boolPtr(true)}, want: false},
+		{name: "env TRUE is case-sensitive and stays disabled", env: "TRUE", want: false},
+		{name: "env any other value stays disabled", env: "1", want: false},
+		{name: "override true beats env false", override: boolPtr(true), env: "false", want: true},
+		{name: "override false beats env true and config enable", override: boolPtr(false), env: "true", cfg: &pubconfig.Clipboard{Enable: boolPtr(true)}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			getEnv := func(key string) string {
+				if key == "GHTKN_CLIPBOARD" {
+					return tt.env
+				}
+				return ""
+			}
+			if got := clipboard(tt.override, tt.cfg, getEnv); got != tt.want {
+				t.Errorf("clipboard() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -34,6 +34,8 @@ func (m *testDeviceFlow) SetOnetimeCodeUI(_ pubdeviceflow.OnetimeCodeUI) {}
 
 func (m *testDeviceFlow) SetBrowser(_ pubdeviceflow.Browser) {}
 
+func (m *testDeviceFlow) SetCopyOnetimeCodeToClipboard(_ pubdeviceflow.CopyTextToClipboard) {}
+
 func TestTokenManager_checkExpired(t *testing.T) {
 	t.Parallel()
 

--- a/ghtkn/internal/api/manager.go
+++ b/ghtkn/internal/api/manager.go
@@ -88,6 +88,7 @@ type deviceFlow interface {
 	SetLogger(logger *publog.Logger)
 	SetOnetimeCodeUI(ui pubdeviceflow.OnetimeCodeUI)
 	SetBrowser(browser pubdeviceflow.Browser)
+	SetCopyOnetimeCodeToClipboard(f pubdeviceflow.CopyTextToClipboard)
 }
 
 // Backend defines the interface for storing and retrieving tokens from the system keyring.

--- a/ghtkn/internal/api/manager_test.go
+++ b/ghtkn/internal/api/manager_test.go
@@ -23,6 +23,8 @@ func (m *mockDeviceFlow) SetOnetimeCodeUI(_ pubdeviceflow.OnetimeCodeUI) {}
 
 func (m *mockDeviceFlow) SetBrowser(_ pubdeviceflow.Browser) {}
 
+func (m *mockDeviceFlow) SetCopyOnetimeCodeToClipboard(_ pubdeviceflow.CopyTextToClipboard) {}
+
 func (m *mockDeviceFlow) Create(_ context.Context, logger *slog.Logger, input *deviceflow.InputCreate) (*deviceflow.AccessToken, error) {
 	if m.err != nil {
 		return nil, m.err

--- a/ghtkn/internal/deviceflow/client.go
+++ b/ghtkn/internal/deviceflow/client.go
@@ -37,3 +37,9 @@ func (c *Client) SetOnetimeCodeUI(ui pubdeviceflow.OnetimeCodeUI) {
 func (c *Client) SetBrowser(b pubdeviceflow.Browser) {
 	c.input.Browser = b
 }
+
+// SetCopyOnetimeCodeToClipboard updates the clipboard implementation used to copy the one-time code.
+// This allows customization of how the one-time code is copied to the user's clipboard.
+func (c *Client) SetCopyOnetimeCodeToClipboard(f pubdeviceflow.CopyTextToClipboard) {
+	c.input.CopyOnetimeCodeToClipboard = f
+}

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -65,10 +65,23 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 	// show the right instruction and we only attempt an open that can succeed.
 	willOpen := c.isOpenBrowser(input)
 
+	// Copy the one-time code to the clipboard before showing it, so the UI can tell
+	// the user it is already on their clipboard. A copy failure must not abort the
+	// device flow: warn and continue so the user can still copy the code manually.
+	copied := false
+	if c.input.CopyOnetimeCodeToClipboard != nil {
+		if err := c.input.CopyOnetimeCodeToClipboard(ctx, deviceCode.UserCode); err != nil {
+			logger.Warn("failed to copy the one-time code to the clipboard", slog.Any("error", err))
+		} else {
+			copied = true
+		}
+	}
+
 	deviceCodeExpirationDate := c.input.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
 	if err := c.input.OnetimeCodeUI.Show(ctx, logger, deviceCode, deviceCodeExpirationDate, &pubdeviceflow.InputShow{
-		OpenBrowser: willOpen,
-		AppName:     input.AppName,
+		OpenBrowser:       willOpen,
+		AppName:           input.AppName,
+		CopiedToClipboard: copied,
 	}); err != nil {
 		return nil, fmt.Errorf("show device code: %w", err)
 	}

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -75,7 +75,7 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 	copied := false
 	if input.Clipboard && c.input.CopyOnetimeCodeToClipboard != nil {
 		if err := c.input.CopyOnetimeCodeToClipboard(ctx, deviceCode.UserCode); err != nil {
-			slogerr.WithError(logger, err).Warn("copy the one-time code to the clipboard")
+			c.input.Logger.FailedToCopyOnetimeCodeToClipboard(logger, c.input.Stderr, err)
 		} else {
 			copied = true
 		}

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -71,7 +71,7 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 	copied := false
 	if c.input.CopyOnetimeCodeToClipboard != nil {
 		if err := c.input.CopyOnetimeCodeToClipboard(ctx, deviceCode.UserCode); err != nil {
-			logger.Warn("failed to copy the one-time code to the clipboard", slog.Any("error", err))
+			slogerr.WithError(logger, err).Warn("copy the one-time code to the clipboard")
 		} else {
 			copied = true
 		}

--- a/ghtkn/internal/deviceflow/create.go
+++ b/ghtkn/internal/deviceflow/create.go
@@ -39,6 +39,10 @@ type InputCreate struct {
 	// automatically. When false, the URL is only shown for the user to open
 	// manually. Even when true, the browser is opened only if one is available.
 	OpenBrowser bool
+	// Clipboard controls whether the one-time code is copied to the system
+	// clipboard. The copy also requires a clipboard implementation to have been
+	// injected via Client.SetCopyOnetimeCodeToClipboard.
+	Clipboard bool
 }
 
 // Create initiates the OAuth device flow and returns an access token.
@@ -69,7 +73,7 @@ func (c *Client) Create(ctx context.Context, logger *slog.Logger, input *InputCr
 	// the user it is already on their clipboard. A copy failure must not abort the
 	// device flow: warn and continue so the user can still copy the code manually.
 	copied := false
-	if c.input.CopyOnetimeCodeToClipboard != nil {
+	if input.Clipboard && c.input.CopyOnetimeCodeToClipboard != nil {
 		if err := c.input.CopyOnetimeCodeToClipboard(ctx, deviceCode.UserCode); err != nil {
 			slogerr.WithError(logger, err).Warn("copy the one-time code to the clipboard")
 		} else {

--- a/ghtkn/internal/deviceflow/create_internal_test.go
+++ b/ghtkn/internal/deviceflow/create_internal_test.go
@@ -3,6 +3,7 @@ package deviceflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -52,6 +53,88 @@ func successHandler() http.HandlerFunc {
 				ExpiresIn:   28800,
 			})
 		}
+	}
+}
+
+func TestClient_Create_clipboard(t *testing.T) {
+	t.Parallel()
+
+	const copiedMsg = "copied to your clipboard"
+
+	tests := []struct {
+		name       string
+		copy       pubdeviceflow.CopyTextToClipboard // nil means no injection
+		wantCode   string                            // code passed to the copy func, if called
+		wantCopied bool                              // stderr shows the "copied" line
+	}{
+		{
+			name:       "no clipboard function does not show the copied line",
+			copy:       nil,
+			wantCopied: false,
+		},
+		{
+			name:       "successful copy shows the copied line",
+			wantCode:   "USER-CODE",
+			wantCopied: true,
+		},
+		{
+			name:       "copy failure does not abort and does not show the copied line",
+			wantCode:   "USER-CODE",
+			wantCopied: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(successHandler())
+			defer server.Close()
+
+			var gotCode string
+			var copyFn pubdeviceflow.CopyTextToClipboard
+			switch tt.name {
+			case "successful copy shows the copied line":
+				copyFn = func(_ context.Context, code string) error {
+					gotCode = code
+					return nil
+				}
+			case "copy failure does not abort and does not show the copied line":
+				copyFn = func(_ context.Context, code string) error {
+					gotCode = code
+					return errors.New("clipboard unavailable")
+				}
+			}
+
+			var stderr strings.Builder
+			input := &Input{
+				HTTPClient:                 &http.Client{Transport: &testTransport{server: server, base: http.DefaultTransport}},
+				Now:                        time.Now,
+				Stderr:                     &stderr,
+				Browser:                    &recordingBrowser{},
+				NewTicker:                  func(_ time.Duration) *time.Ticker { return time.NewTicker(time.Millisecond) },
+				Logger:                     log.NewLogger(),
+				OnetimeCodeUI:              newOnetimeCodeUI(strings.NewReader("\n"), &stderr, &mockWaiter{}),
+				CopyOnetimeCodeToClipboard: copyFn,
+			}
+
+			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), &InputCreate{
+				ClientID:    "test-client-id",
+				OpenBrowser: true,
+			})
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+			if tk.AccessToken != "gho_testtoken123" {
+				t.Fatalf("AccessToken = %q, want gho_testtoken123", tk.AccessToken)
+			}
+			if tt.wantCode != "" && gotCode != tt.wantCode {
+				t.Errorf("copied code = %q, want %q", gotCode, tt.wantCode)
+			}
+			if got := strings.Contains(stderr.String(), copiedMsg); got != tt.wantCopied {
+				t.Errorf("copied line shown = %v, want %v\nstderr:\n%s", got, tt.wantCopied, stderr.String())
+			}
+		})
 	}
 }
 

--- a/ghtkn/internal/deviceflow/create_internal_test.go
+++ b/ghtkn/internal/deviceflow/create_internal_test.go
@@ -63,24 +63,35 @@ func TestClient_Create_clipboard(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		copy       pubdeviceflow.CopyTextToClipboard // nil means no injection
-		wantCode   string                            // code passed to the copy func, if called
-		wantCopied bool                              // stderr shows the "copied" line
+		enabled    bool // InputCreate.Clipboard
+		inject     bool // whether a copy function is injected
+		copyErr    bool // the injected copy function returns an error
+		wantCalled bool // the copy function is invoked
+		wantCopied bool // stderr shows the "copied" line
 	}{
 		{
-			name:       "no clipboard function does not show the copied line",
-			copy:       nil,
-			wantCopied: false,
+			name:    "disabled with a function injected does not copy",
+			enabled: false,
+			inject:  true,
 		},
 		{
-			name:       "successful copy shows the copied line",
-			wantCode:   "USER-CODE",
+			name:    "enabled without a function injected does not show the copied line",
+			enabled: true,
+			inject:  false,
+		},
+		{
+			name:       "enabled with a successful copy shows the copied line",
+			enabled:    true,
+			inject:     true,
+			wantCalled: true,
 			wantCopied: true,
 		},
 		{
-			name:       "copy failure does not abort and does not show the copied line",
-			wantCode:   "USER-CODE",
-			wantCopied: false,
+			name:       "enabled but copy fails does not abort and does not show the copied line",
+			enabled:    true,
+			inject:     true,
+			copyErr:    true,
+			wantCalled: true,
 		},
 	}
 
@@ -93,16 +104,13 @@ func TestClient_Create_clipboard(t *testing.T) {
 
 			var gotCode string
 			var copyFn pubdeviceflow.CopyTextToClipboard
-			switch tt.name {
-			case "successful copy shows the copied line":
+			if tt.inject {
 				copyFn = func(_ context.Context, code string) error {
 					gotCode = code
+					if tt.copyErr {
+						return errors.New("clipboard unavailable")
+					}
 					return nil
-				}
-			case "copy failure does not abort and does not show the copied line":
-				copyFn = func(_ context.Context, code string) error {
-					gotCode = code
-					return errors.New("clipboard unavailable")
 				}
 			}
 
@@ -121,6 +129,7 @@ func TestClient_Create_clipboard(t *testing.T) {
 			tk, err := NewClient(input).Create(t.Context(), slog.New(slog.DiscardHandler), &InputCreate{
 				ClientID:    "test-client-id",
 				OpenBrowser: true,
+				Clipboard:   tt.enabled,
 			})
 			if err != nil {
 				t.Fatalf("Create() error = %v", err)
@@ -128,8 +137,12 @@ func TestClient_Create_clipboard(t *testing.T) {
 			if tk.AccessToken != "gho_testtoken123" {
 				t.Fatalf("AccessToken = %q, want gho_testtoken123", tk.AccessToken)
 			}
-			if tt.wantCode != "" && gotCode != tt.wantCode {
-				t.Errorf("copied code = %q, want %q", gotCode, tt.wantCode)
+			called := gotCode != ""
+			if called != tt.wantCalled {
+				t.Errorf("copy function called = %v, want %v", called, tt.wantCalled)
+			}
+			if tt.wantCalled && gotCode != "USER-CODE" {
+				t.Errorf("copied code = %q, want USER-CODE", gotCode)
 			}
 			if got := strings.Contains(stderr.String(), copiedMsg); got != tt.wantCopied {
 				t.Errorf("copied line shown = %v, want %v\nstderr:\n%s", got, tt.wantCopied, stderr.String())

--- a/ghtkn/internal/deviceflow/device_ui.go
+++ b/ghtkn/internal/deviceflow/device_ui.go
@@ -43,12 +43,17 @@ func (d *simpleOnetimeCodeUI) Show(ctx context.Context, _ *slog.Logger, deviceCo
 	msgHeader := `The application uses the device flow to generate your GitHub User Access Token.
 Copy your one-time code: %s
 `
+	if input.CopiedToClipboard {
+		msgHeader += `(The one-time code has been copied to your clipboard.)
+`
+	}
 	if input.AppName != "" {
 		msgHeader += `App Name: %s
 `
 	}
 	msgHeader += `This code is valid until %s
 `
+
 	// Build the format arguments to match the verbs in msgHeader. The App Name
 	// line (and its verb) is only present when AppName is set, so AppName must be
 	// omitted from the arguments otherwise to keep verbs and arguments aligned.

--- a/ghtkn/internal/deviceflow/types.go
+++ b/ghtkn/internal/deviceflow/types.go
@@ -20,13 +20,14 @@ import (
 // It allows for dependency injection and makes testing easier by providing
 // customizable implementations of external dependencies.
 type Input struct {
-	HTTPClient    *http.Client                       // HTTP client for API requests
-	Now           func() time.Time                   // Function to get current time (for testing)
-	Stderr        io.Writer                          // Writer for error output
-	Browser       pubdeviceflow.Browser              // Interface for opening URLs in browser
-	NewTicker     func(d time.Duration) *time.Ticker // Function to create tickers (for testing)
-	Logger        *publog.Logger                     // Logger for debugging and info messages
-	OnetimeCodeUI pubdeviceflow.OnetimeCodeUI        // UI for displaying the one-time code (user code)
+	HTTPClient                 *http.Client                       // HTTP client for API requests
+	Now                        func() time.Time                   // Function to get current time (for testing)
+	Stderr                     io.Writer                          // Writer for error output
+	Browser                    pubdeviceflow.Browser              // Interface for opening URLs in browser
+	NewTicker                  func(d time.Duration) *time.Ticker // Function to create tickers (for testing)
+	Logger                     *publog.Logger                     // Logger for debugging and info messages
+	OnetimeCodeUI              pubdeviceflow.OnetimeCodeUI        // UI for displaying the one-time code (user code)
+	CopyOnetimeCodeToClipboard pubdeviceflow.CopyTextToClipboard  // Function to copy one-time code to clipboard
 }
 
 // NewInput creates a new Input instance with default dependencies.

--- a/ghtkn/internal/log/log.go
+++ b/ghtkn/internal/log/log.go
@@ -3,6 +3,8 @@
 package log
 
 import (
+	"fmt"
+	"io"
 	"log/slog"
 	"time"
 
@@ -19,6 +21,10 @@ func NewLogger() *publog.Logger {
 		},
 		FailedToOpenBrowser: func(logger *slog.Logger, err error) {
 			slogerr.WithError(logger, err).Warn("failed to open the browser")
+		},
+		FailedToCopyOnetimeCodeToClipboard: func(logger *slog.Logger, stderr io.Writer, err error) {
+			fmt.Fprintln(stderr, err) //nolint:errcheck
+			logger.Warn("Failed to copy the one-time code to the clipboard automatically. Please copy it manually")
 		},
 		OpenedBrowser: func(logger *slog.Logger, url string) {
 			logger.Info("opened the browser", "url", url)
@@ -39,6 +45,9 @@ func InitLogger(l *publog.Logger) {
 	}
 	if l.FailedToOpenBrowser == nil {
 		l.FailedToOpenBrowser = defaultLogger.FailedToOpenBrowser
+	}
+	if l.FailedToCopyOnetimeCodeToClipboard == nil {
+		l.FailedToCopyOnetimeCodeToClipboard = defaultLogger.FailedToCopyOnetimeCodeToClipboard
 	}
 	if l.OpenedBrowser == nil {
 		l.OpenedBrowser = defaultLogger.OpenedBrowser

--- a/ghtkn/log/log.go
+++ b/ghtkn/log/log.go
@@ -3,6 +3,7 @@
 package log
 
 import (
+	"io"
 	"log/slog"
 	"time"
 )
@@ -14,6 +15,8 @@ type Logger struct {
 	Expire func(logger *slog.Logger, exDate time.Time)
 	// FailedToOpenBrowser logs when the browser cannot be opened for authentication.
 	FailedToOpenBrowser func(logger *slog.Logger, err error)
+	// FailedToCopyOnetimeCodeToClipboard logs when the one-time code cannot be copied to the clipboard.
+	FailedToCopyOnetimeCodeToClipboard func(logger *slog.Logger, stderr io.Writer, err error)
 	// OpenedBrowser logs when the browser has been opened for authentication.
 	OpenedBrowser func(logger *slog.Logger, url string)
 	// AccessTokenIsNotFoundInBackend logs when no access token is found in the backend.


### PR DESCRIPTION
## Overview

This adds support for copying the device flow one-time (user) code to the system clipboard, without the SDK taking on any clipboard dependency.

During the device flow, GitHub returns a one-time code that the user must paste into the verification page. Copying it automatically is a convenience, but the copy has to happen inside the SDK's device flow where the code is known. Pulling a clipboard library (e.g. `golang.design/x/clipboard` and its large transitive tree) into this reusable module would force it onto every consumer. Instead, this PR exposes a function-type injection point and lets the consumer (the `ghtkn` CLI) supply the implementation — the same shape already used for `Browser` / `open_browser`.

## Design

Clipboard copying is a tri-source option that mirrors `open_browser`:

- Precedence (default off): explicit override (`InputGet.Clipboard`, set by the CLI's `-clipboard` flag) > `GHTKN_CLIPBOARD` env (only `"true"` enables) > config `clipboard.enable` > disabled.
- The SDK resolves the decision (`clipboard()` in `internal/api/get.go`) and gates the copy on it.
- The actual clipboard write is performed by a function injected via `Client.SetCopyOnetimeCodeToClipboard`, so the SDK keeps no clipboard dependency.

## Changes

- Add `deviceflow.CopyTextToClipboard` (`func(ctx, code string) error`) and `Client.SetCopyOnetimeCodeToClipboard`, threaded through the existing layers (`client.go` → `internal/api` → `internal/deviceflow`).
- Add `config.Clipboard{ Enable *bool }` and `Config.Clipboard`; add `InputGet.Clipboard *bool`.
- Add the `clipboard()` resolver and thread the resolved bool down to `deviceflow.InputCreate.Clipboard`.
- Perform the copy in `internal/deviceflow/create.go`, before showing the code, only when copying is enabled AND an implementation was injected. A copy failure is logged as a warning and does NOT abort authentication, so the user can still copy the code manually.
- The default UI shows `(The one-time code has been copied to your clipboard.)` only when the copy actually succeeded (`InputShow.CopiedToClipboard`), so the message never overstates what happened.
- Tests: `create_internal_test.go` covers disabled / enabled-no-func / success / failure-doesn't-abort; `get_test.go` covers `clipboard()` precedence (override > env > config > default-off).

## Security note

The earlier exclusion of env/config (and of git-credential) on phishing grounds was reconsidered and dropped: ghtkn never places an attacker's code on the clipboard (it only copies the code from the device flow it runs and polls itself), and the opt-in mechanism doesn't change the threat. The risk-relevant choice is default-off (kept) plus always displaying the real code (kept). So clipboard is a normal tri-source option.

## Note

This branch was rebased on `main` after `device_flow` was removed from the config file (#363) and the automatic device flow was disabled by default (#364), so this PR no longer touches `device_flow.enable`.

## Consumer

The `ghtkn` CLI side (the `-p`/`--clipboard` flag, `golang.design/x/clipboard` implementation, and JSON Schema regen) is a separate PR that bumps this module once released.
