### PR TITLE
feat: remove device_flow setting from the config file

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -21,8 +21,8 @@ type InputGet struct {
 	MinExpiration *time.Duration
 	// EnableDeviceFlow overrides whether the OAuth device flow may run to create a
 	// new token. nil means "not specified", in which case the GHTKN_ENABLE_DEVICE_FLOW
-	// environment variable and then the config's device_flow.enable decide (default
-	// enabled; set the environment variable to "false" to disable).
+	// environment variable decides (default enabled; set the environment variable to
+	// "false" to disable).
 	EnableDeviceFlow *bool
 }
 

--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -26,8 +26,6 @@ type Config struct {
 	// expired). The -min-expiration flag and the GHTKN_MIN_EXPIRATION environment
 	// variable take precedence over this value.
 	MinExpiration string `json:"min_expiration,omitempty" yaml:"min_expiration"`
-	// DeviceFlow configures whether the OAuth device flow may run to create a new token.
-	DeviceFlow *DeviceFlow `json:"device_flow,omitempty" yaml:"device_flow"`
 	// Backend selects the storage backend for access tokens.
 	Backend *Backend `json:"backend,omitempty" yaml:"backend"`
 }
@@ -37,15 +35,6 @@ type OpenBrowser struct {
 	// Enable toggles automatic browser opening. nil means "not specified" and
 	// defaults to true. The GHTKN_OPEN_BROWSER environment variable, when set,
 	// takes precedence over this value.
-	Enable *bool `json:"enable,omitempty" yaml:"enable"`
-}
-
-// DeviceFlow configures whether the OAuth device flow may run to create a new
-// access token.
-type DeviceFlow struct {
-	// Enable toggles whether the device flow may run. nil means "not specified" and
-	// defaults to true. The -device-flow flag and the GHTKN_ENABLE_DEVICE_FLOW
-	// environment variable take precedence over this value.
 	Enable *bool `json:"enable,omitempty" yaml:"enable"`
 }
 

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -100,7 +100,7 @@ func (tm *TokenManager) Get(ctx context.Context, logger *slog.Logger, input *pub
 		MinExpiration:     minExpiration,
 		App:               app,
 		Backend:           b,
-		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, cfg.DeviceFlow, tm.input.Getenv),
+		EnableDeviceFlow:  enableDeviceFlow(input.EnableDeviceFlow, tm.input.Getenv),
 		SkipAccountPicker: skipAccountPicker(cfg.SkipAccountPicker),
 		OpenBrowser:       openBrowser(cfg.OpenBrowser, tm.input.Getenv),
 	})
@@ -139,17 +139,13 @@ type inputGetOrCreateToken struct {
 
 // enableDeviceFlow resolves whether the device flow may run. An explicit override
 // (the -device-flow flag) takes precedence; otherwise the GHTKN_ENABLE_DEVICE_FLOW
-// environment variable decides (only "false" disables it), then the config's
-// device_flow.enable, defaulting to enabled.
-func enableDeviceFlow(override *bool, cfg *pubconfig.DeviceFlow, getEnv func(string) string) bool {
+// environment variable decides (only "false" disables it), defaulting to enabled.
+func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
 	if override != nil {
 		return *override
 	}
 	if v := getEnv("GHTKN_ENABLE_DEVICE_FLOW"); v != "" {
 		return v != "false"
-	}
-	if cfg != nil && cfg.Enable != nil {
-		return *cfg.Enable
 	}
 	return true
 }

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -187,18 +187,13 @@ func TestEnableDeviceFlow(t *testing.T) {
 		name     string
 		override *bool
 		env      string
-		cfg      *bool // device_flow.enable in the config file
 		want     bool
 	}{
-		{name: "default enabled when all unset", override: nil, env: "", cfg: nil, want: true},
+		{name: "default enabled when all unset", override: nil, env: "", want: true},
 		{name: "env false disables", override: nil, env: "false", want: false},
 		{name: "env true enables", override: nil, env: "true", want: true},
 		{name: "override true beats env false", override: ptr(true), env: "false", want: true},
 		{name: "override false beats env true", override: ptr(false), env: "true", want: false},
-		{name: "config false disables when override and env unset", override: nil, env: "", cfg: ptr(false), want: false},
-		{name: "config true enables when override and env unset", override: nil, env: "", cfg: ptr(true), want: true},
-		{name: "env beats config", override: nil, env: "false", cfg: ptr(true), want: false},
-		{name: "override beats config", override: ptr(false), env: "", cfg: ptr(true), want: false},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
@@ -209,11 +204,7 @@ func TestEnableDeviceFlow(t *testing.T) {
 				}
 				return ""
 			}
-			var cfg *pubconfig.DeviceFlow
-			if d.cfg != nil {
-				cfg = &pubconfig.DeviceFlow{Enable: d.cfg}
-			}
-			if got := enableDeviceFlow(d.override, cfg, getEnv); got != d.want {
+			if got := enableDeviceFlow(d.override, getEnv); got != d.want {
 				t.Errorf("enableDeviceFlow = %v, want %v", got, d.want)
 			}
 		})

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -48,9 +48,6 @@
         "min_expiration": {
           "type": "string"
         },
-        "device_flow": {
-          "$ref": "#/$defs/DeviceFlow"
-        },
         "backend": {
           "$ref": "#/$defs/Backend"
         }
@@ -60,15 +57,6 @@
       "required": [
         "apps"
       ]
-    },
-    "DeviceFlow": {
-      "properties": {
-        "enable": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
     },
     "OpenBrowser": {
       "properties": {


### PR DESCRIPTION
Part of suzuki-shunsuke/ghtkn#474.

## What

Remove the config file's `device_flow.enable` setting, along with the `DeviceFlow` config type and its references.

That setting was introduced in #357 and has not been released yet, so removing it is not a breaking change.

This is one step of suzuki-shunsuke/ghtkn#474, which makes the OAuth device flow safer by no longer starting it automatically from `ghtkn get` / `git-credential` / the SDK.

## Scope

Only the config file knob is removed. The other ways to control the device flow are kept, since removing them is a separate later phase of the rollout:

- the `-d` (`-device-flow`) flag / `InputGet.EnableDeviceFlow`
- the `GHTKN_ENABLE_DEVICE_FLOW` environment variable

The device flow feature itself (the `deviceflow` packages, the `DeviceFlow` client interface) is unchanged.

## Changes

- `ghtkn/config/config.go`: drop the `Config.DeviceFlow` field and the `DeviceFlow` struct.
- `ghtkn/internal/api/get.go`: `enableDeviceFlow` no longer takes the config value. It now resolves from the flag override, then `GHTKN_ENABLE_DEVICE_FLOW`, defaulting to enabled. The doc comment is updated accordingly.
- `ghtkn/internal/api/helper_internal_test.go`: drop the config-based cases from `TestEnableDeviceFlow`.
- `ghtkn/api/api.go`: update the `EnableDeviceFlow` doc comment to no longer mention `device_flow.enable`.
- `json-schema/ghtkn.json`: remove the `device_flow` property and its `DeviceFlow` definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)