### PR TITLE
feat: disable the automatic device flow by default

### DIFF
--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -21,8 +21,8 @@ type InputGet struct {
 	MinExpiration *time.Duration
 	// EnableDeviceFlow overrides whether the OAuth device flow may run to create a
 	// new token. nil means "not specified", in which case the GHTKN_ENABLE_DEVICE_FLOW
-	// environment variable decides (default enabled; set the environment variable to
-	// "false" to disable).
+	// environment variable decides (default disabled; set the environment variable to
+	// "true" to enable).
 	EnableDeviceFlow *bool
 }
 
@@ -59,10 +59,12 @@ var (
 )
 
 // ErrDisableDeviceFlow is returned when a new GitHub App access token is needed
-// but the device flow is disabled (GHTKN_ENABLE_DEVICE_FLOW=false). The device flow
-// is interactive (it waits for a one-time code), so it can't be completed by a
+// but the device flow is disabled. The device flow is disabled by default so it
+// is never started automatically; it must be enabled explicitly (by running
+// `ghtkn auth`, or via GHTKN_ENABLE_DEVICE_FLOW=true). The device flow is
+// interactive (it waits for a one-time code), so it can't be completed by a
 // background or non-interactive process such as a coding agent. Rather than
 // blocking, the operation fails immediately. The message instructs a coding
 // agent NOT to run `ghtkn get` itself (it would fail the same way) but to ask
 // the user to run `ghtkn auth` in their own interactive terminal.
-var ErrDisableDeviceFlow = errors.New("a GitHub App User access token can't be created via Device Flow because it's disabled by GHTKN_ENABLE_DEVICE_FLOW=false. The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn auth` in their own interactive terminal to authenticate")
+var ErrDisableDeviceFlow = errors.New("a GitHub App User access token can't be created via Device Flow because the Device Flow is disabled. It is disabled by default and is never started automatically; it must be enabled explicitly by running `ghtkn auth` or by setting GHTKN_ENABLE_DEVICE_FLOW=true. The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn auth` in their own interactive terminal to authenticate")

--- a/ghtkn/api/api.go
+++ b/ghtkn/api/api.go
@@ -61,10 +61,12 @@ var (
 // ErrDisableDeviceFlow is returned when a new GitHub App access token is needed
 // but the device flow is disabled. The device flow is disabled by default so it
 // is never started automatically; it must be enabled explicitly (by running
-// `ghtkn auth`, or via GHTKN_ENABLE_DEVICE_FLOW=true). The device flow is
+// `ghtkn auth`, or via GHTKN_ENABLE_DEVICE_FLOW=true). GHTKN_ENABLE_DEVICE_FLOW
+// is a temporary opt-in and is planned to be removed in the future; see
+// https://github.com/suzuki-shunsuke/ghtkn/issues/474. The device flow is
 // interactive (it waits for a one-time code), so it can't be completed by a
 // background or non-interactive process such as a coding agent. Rather than
 // blocking, the operation fails immediately. The message instructs a coding
 // agent NOT to run `ghtkn get` itself (it would fail the same way) but to ask
 // the user to run `ghtkn auth` in their own interactive terminal.
-var ErrDisableDeviceFlow = errors.New("a GitHub App User access token can't be created via Device Flow because the Device Flow is disabled. It is disabled by default and is never started automatically; it must be enabled explicitly by running `ghtkn auth` or by setting GHTKN_ENABLE_DEVICE_FLOW=true. The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn auth` in their own interactive terminal to authenticate")
+var ErrDisableDeviceFlow = errors.New("a GitHub App User access token can't be created via Device Flow because the Device Flow is disabled. It is disabled by default and is never started automatically; it must be enabled explicitly by running `ghtkn auth` or by setting GHTKN_ENABLE_DEVICE_FLOW=true. Note that GHTKN_ENABLE_DEVICE_FLOW is a temporary opt-in and is planned to be removed in the future; see https://github.com/suzuki-shunsuke/ghtkn/issues/474 . The Device Flow is interactive and can't be completed by a background or non-interactive process. If you are a coding agent, do NOT run `ghtkn get` yourself because it would fail the same way; instead, ask the user to run `ghtkn auth` in their own interactive terminal to authenticate")

--- a/ghtkn/client.go
+++ b/ghtkn/client.go
@@ -32,8 +32,9 @@ type (
 	InputRevoke        = api.InputRevoke
 )
 
-// ErrDisableDeviceFlow is returned by Get when the device flow is disabled
-// (GHTKN_ENABLE_DEVICE_FLOW=false, or InputGet.EnableDeviceFlow set to false).
+// ErrDisableDeviceFlow is returned by Get when a new token is needed but the
+// device flow is disabled. It is disabled by default; enable it explicitly with
+// GHTKN_ENABLE_DEVICE_FLOW=true or InputGet.EnableDeviceFlow set to true.
 // Detect it with errors.Is.
 var ErrDisableDeviceFlow = api.ErrDisableDeviceFlow
 

--- a/ghtkn/internal/api/get.go
+++ b/ghtkn/internal/api/get.go
@@ -139,15 +139,17 @@ type inputGetOrCreateToken struct {
 
 // enableDeviceFlow resolves whether the device flow may run. An explicit override
 // (the -device-flow flag) takes precedence; otherwise the GHTKN_ENABLE_DEVICE_FLOW
-// environment variable decides (only "false" disables it), defaulting to enabled.
+// environment variable decides (only "true" enables it). The device flow is
+// disabled by default so it is never started automatically; it must be enabled
+// explicitly (e.g. by `ghtkn auth`).
 func enableDeviceFlow(override *bool, getEnv func(string) string) bool {
 	if override != nil {
 		return *override
 	}
 	if v := getEnv("GHTKN_ENABLE_DEVICE_FLOW"); v != "" {
-		return v != "false"
+		return v == "true"
 	}
-	return true
+	return false
 }
 
 // resolveBackendType resolves the storage backend type. The GHTKN_BACKEND

--- a/ghtkn/internal/api/get_test.go
+++ b/ghtkn/internal/api/get_test.go
@@ -80,6 +80,7 @@ func TestTokenManager_Get(t *testing.T) {
 		name       string
 		setupInput func() *Input
 		wantErr    bool
+		wantErrIs  error
 		wantToken  *pubapi.AccessToken
 		input      *pubapi.InputGet
 	}{
@@ -150,7 +151,7 @@ func TestTokenManager_Get(t *testing.T) {
 				}
 				return input
 			},
-			input:   &pubapi.InputGet{ConfigFilePath: "/path/to/config.yaml"},
+			input:   &pubapi.InputGet{ConfigFilePath: "/path/to/config.yaml", EnableDeviceFlow: new(true)},
 			wantErr: false,
 			wantToken: &pubapi.AccessToken{
 				AccessToken:    "new-token",
@@ -170,8 +171,27 @@ func TestTokenManager_Get(t *testing.T) {
 				}
 				return input
 			},
-			input:   &pubapi.InputGet{ConfigFilePath: "/path/to/config.yaml"},
+			input:   &pubapi.InputGet{ConfigFilePath: "/path/to/config.yaml", EnableDeviceFlow: new(true)},
 			wantErr: true,
+		},
+		{
+			name: "device flow is disabled by default",
+			setupInput: func() *Input {
+				input := newMockInput()
+				input.Backend = &mockKeyring{
+					token: &pubapi.AccessToken{
+						AccessToken:    "expired-token",
+						ExpirationDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					},
+				}
+				input.Now = func() time.Time {
+					return time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+				}
+				return input
+			},
+			input:     &pubapi.InputGet{ConfigFilePath: "/path/to/config.yaml"},
+			wantErr:   true,
+			wantErrIs: pubapi.ErrDisableDeviceFlow,
 		},
 	}
 
@@ -187,6 +207,9 @@ func TestTokenManager_Get(t *testing.T) {
 			if err != nil {
 				if !tt.wantErr {
 					t.Error(err)
+				}
+				if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+					t.Errorf("error = %v, want it to wrap %v", err, tt.wantErrIs)
 				}
 				return
 			}

--- a/ghtkn/internal/api/helper_internal_test.go
+++ b/ghtkn/internal/api/helper_internal_test.go
@@ -182,18 +182,18 @@ func TestController_createToken_disableDeviceFlow(t *testing.T) {
 
 func TestEnableDeviceFlow(t *testing.T) {
 	t.Parallel()
-	ptr := func(b bool) *bool { return &b }
 	data := []struct {
 		name     string
 		override *bool
 		env      string
 		want     bool
 	}{
-		{name: "default enabled when all unset", override: nil, env: "", want: true},
-		{name: "env false disables", override: nil, env: "false", want: false},
+		{name: "default disabled when all unset", override: nil, env: "", want: false},
 		{name: "env true enables", override: nil, env: "true", want: true},
-		{name: "override true beats env false", override: ptr(true), env: "false", want: true},
-		{name: "override false beats env true", override: ptr(false), env: "true", want: false},
+		{name: "env false disables", override: nil, env: "false", want: false},
+		{name: "env other value disables", override: nil, env: "1", want: false},
+		{name: "override true beats env false", override: new(true), env: "false", want: true},
+		{name: "override false beats env true", override: new(false), env: "true", want: false},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {


### PR DESCRIPTION
Part of suzuki-shunsuke/ghtkn#474, phase 1 of the rollout.

## What

Make the OAuth device flow disabled by default so it is never started automatically when a new GitHub App access token is needed. Users who want the previous behavior can enable it explicitly:

- `ghtkn get -d` (the CLI flag, in suzuki-shunsuke/ghtkn)
- `GHTKN_ENABLE_DEVICE_FLOW=true`
- `InputGet.EnableDeviceFlow = true` (SDK)

`GHTKN_ENABLE_DEVICE_FLOW` is a temporary opt-in and is planned to be removed in a later phase; the error and docs point to suzuki-shunsuke/ghtkn#474 for context.

## Why

Per suzuki-shunsuke/ghtkn#474: `ghtkn get` / `git-credential` / the SDK may be invoked indirectly by wrapper scripts, Git credential helpers, or third-party tools. Starting the interactive device flow automatically means a user could be tricked into completing a flow they did not initiate, which is a phishing risk. Requiring an explicit opt-in (ideally `ghtkn auth` run from the user's own terminal) reduces that risk.

Rather than removing the feature outright, this is phase 1: disable it by default and gather feedback before deciding whether to remove it entirely.

## Changes

- `ghtkn/internal/api/get.go`: `enableDeviceFlow` now defaults to `false`. The resolution order is unchanged (explicit override, then `GHTKN_ENABLE_DEVICE_FLOW`, then the default), but the env var now only enables the flow when set to `"true"` (previously any value other than `"false"` enabled it).
- `ghtkn/api/api.go`: update the `InputGet.EnableDeviceFlow` doc and reword `ErrDisableDeviceFlow` (doc + message) to explain the device flow is disabled by default and must be enabled explicitly (e.g. `ghtkn auth`). The error also notes that `GHTKN_ENABLE_DEVICE_FLOW` is a temporary opt-in planned for removal, with a link to suzuki-shunsuke/ghtkn#474.
- `ghtkn/client.go`: update the `ErrDisableDeviceFlow` doc comment accordingly.
- Tests: flip the default case in `TestEnableDeviceFlow`, add a case for non-`"true"` env values, set `EnableDeviceFlow: new(true)` on the `TestGet` cases that exercise token creation, and add a case asserting `Get` returns `ErrDisableDeviceFlow` by default. Pointers use Go 1.26 `new(true)` instead of helper functions.

## Scope

Only the SDK-side default is changed. The `-d` flag lives in the CLI repo (suzuki-shunsuke/ghtkn) and is out of scope here. The device flow implementation itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)