### PR TITLE
fix: send the browser command's stdout to stderr

### DIFF
--- a/ghtkn/browser/browser.go
+++ b/ghtkn/browser/browser.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
@@ -64,10 +65,29 @@ func (b *Browser) runCmd(ctx context.Context, url string) error {
 		if _, err := b.findCmd(cmd); err != nil {
 			continue
 		}
-		if err := command(ctx, cmd, url).Run(); err != nil {
+		if err := browserCmd(ctx, cmd, url).Run(); err != nil {
 			return fmt.Errorf("open the browser: %w", slogerr.With(err, "command_to_open_browser", cmd))
 		}
 		return nil
 	}
 	return ErrNoCommandFound
+}
+
+// browserCmd builds the command that opens url, sending its standard output to
+// standard error.
+//
+// Nothing a browser command writes to stdout is meaningful, while the stdout of the
+// process opening the browser carries data its caller parses: 'ghtkn get' writes the
+// access token there, and 'ghtkn git-credential' speaks git's credential protocol.
+// A single line from the browser command would corrupt either one, and the resulting
+// failure would look like a bad token rather than like browser output. On Linux the
+// browser command can even be a text browser, since the www-browser alternative
+// resolves to w3m or lynx on some hosts, and those render the whole page to stdout.
+//
+// The rest of the defaults, including stderr and the signal handling, come from
+// command, which is kept identical to its upstream copy.
+func browserCmd(ctx context.Context, name, url string) *exec.Cmd {
+	cmd := command(ctx, name, url)
+	cmd.Stdout = os.Stderr
+	return cmd
 }

--- a/ghtkn/browser/browser.go
+++ b/ghtkn/browser/browser.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -23,6 +24,36 @@ type Browser struct {
 	// a stub instead of driving the real PATH via t.Setenv (which forbids t.Parallel). A
 	// nil value falls back to exec.LookPath.
 	lookPath func(file string) (string, error)
+	// stdout receives the standard output of the command that opens the browser. A nil
+	// value falls back to os.Stderr; see SetStdout for why it is never the standard
+	// output of the process opening the browser.
+	stdout io.Writer
+}
+
+// SetStdout sets the writer that receives the standard output of the command opening
+// the browser. Passing nil restores the default, os.Stderr.
+//
+// The default is os.Stderr rather than os.Stdout because the standard output of the
+// process opening the browser carries data its caller parses: a CLI built on this SDK
+// writes the access token there, and a git credential helper speaks git's credential
+// protocol there. A single line from the browser command corrupts either one, and the
+// resulting failure looks like a bad token rather than like browser output. On Linux
+// the browser command can even be a text browser, since the www-browser alternative
+// resolves to w3m or lynx on some hosts, and those render the whole page to stdout.
+//
+// Set this when the process embedding the SDK needs that output somewhere else, such
+// as a log or io.Discard, instead of on its standard error.
+func (b *Browser) SetStdout(w io.Writer) {
+	b.stdout = w
+}
+
+// stdoutWriter returns the writer for the browser command's standard output, using
+// the injected stdout or os.Stderr by default.
+func (b *Browser) stdoutWriter() io.Writer {
+	if b.stdout != nil {
+		return b.stdout
+	}
+	return os.Stderr
 }
 
 // findCmd resolves cmd on PATH, using the injected lookPath or exec.LookPath by default.
@@ -62,10 +93,14 @@ func (b *Browser) hasCmd() bool {
 // Returns errNoCommandFound if no suitable command is available.
 func (b *Browser) runCmd(ctx context.Context, url string) error {
 	for _, cmd := range cmds() {
-		if _, err := b.findCmd(cmd); err != nil {
+		// Run the resolved path rather than the bare name: it is what findCmd looked
+		// up, and it lets tests drive runCmd through the injected lookPath without
+		// touching PATH or launching a real browser.
+		path, err := b.findCmd(cmd)
+		if err != nil {
 			continue
 		}
-		if err := browserCmd(ctx, cmd, url).Run(); err != nil {
+		if err := b.browserCmd(ctx, path, url).Run(); err != nil {
 			return fmt.Errorf("open the browser: %w", slogerr.With(err, "command_to_open_browser", cmd))
 		}
 		return nil
@@ -73,21 +108,14 @@ func (b *Browser) runCmd(ctx context.Context, url string) error {
 	return ErrNoCommandFound
 }
 
-// browserCmd builds the command that opens url, sending its standard output to
-// standard error.
-//
-// Nothing a browser command writes to stdout is meaningful, while the stdout of the
-// process opening the browser carries data its caller parses: 'ghtkn get' writes the
-// access token there, and 'ghtkn git-credential' speaks git's credential protocol.
-// A single line from the browser command would corrupt either one, and the resulting
-// failure would look like a bad token rather than like browser output. On Linux the
-// browser command can even be a text browser, since the www-browser alternative
-// resolves to w3m or lynx on some hosts, and those render the whole page to stdout.
+// browserCmd builds the command that opens url, sending its standard output to the
+// writer from stdoutWriter instead of the standard output of this process. See
+// SetStdout for why that output must not go to os.Stdout.
 //
 // The rest of the defaults, including stderr and the signal handling, come from
 // command, which is kept identical to its upstream copy.
-func browserCmd(ctx context.Context, name, url string) *exec.Cmd {
+func (b *Browser) browserCmd(ctx context.Context, name, url string) *exec.Cmd {
 	cmd := command(ctx, name, url)
-	cmd.Stdout = os.Stderr
+	cmd.Stdout = b.stdoutWriter()
 	return cmd
 }

--- a/ghtkn/browser/browser_internal_test.go
+++ b/ghtkn/browser/browser_internal_test.go
@@ -3,23 +3,64 @@
 package browser
 
 import (
+	"bytes"
 	"errors"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
-// TestBrowserCmd checks that opening a browser can't write to the standard output of
-// the process opening it, which carries the access token in 'ghtkn get' and git's
-// credential protocol in 'ghtkn git-credential'.
-func TestBrowserCmd(t *testing.T) {
+const deviceURL = "https://github.com/login/device"
+
+// TestBrowser_runCmd_stdout checks that the command opening the browser can't write to
+// the standard output of the process opening it, which carries the access token for a
+// CLI built on this SDK and git's credential protocol for a git credential helper.
+//
+// It drives runCmd rather than browserCmd so that building the command any other way
+// fails the test: asserting on browserCmd alone would restate its body and stay green
+// even if runCmd stopped calling it.
+func TestBrowser_runCmd_stdout(t *testing.T) {
 	t.Parallel()
 
-	cmd := browserCmd(t.Context(), "xdg-open", "https://github.com/login/device")
+	// echo stands in for the browser command: runCmd runs the path lookPath resolved,
+	// so no real browser is launched and PATH is left alone.
+	echo, err := exec.LookPath("echo")
+	if err != nil {
+		t.Skipf("echo is not on PATH: %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	b := &Browser{lookPath: func(string) (string, error) { return echo, nil }}
+	b.SetStdout(stdout)
+
+	if err := b.runCmd(t.Context(), deviceURL); err != nil {
+		t.Fatalf("runCmd() = %v, want nil", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != deviceURL {
+		t.Errorf("browser command stdout = %q, want %q; it must not reach os.Stdout", got, deviceURL)
+	}
+}
+
+// TestBrowser_browserCmd_defaultStdout checks the default a caller gets without
+// SetStdout, which the runCmd test can't observe because it injects a writer.
+func TestBrowser_browserCmd_defaultStdout(t *testing.T) {
+	t.Parallel()
+
+	cmd := (&Browser{}).browserCmd(t.Context(), "xdg-open", deviceURL)
 	if cmd.Stdout != os.Stderr {
 		t.Errorf("Stdout = %v, want os.Stderr", cmd.Stdout)
 	}
-	if cmd.Stderr != os.Stderr {
-		t.Errorf("Stderr = %v, want os.Stderr", cmd.Stderr)
+}
+
+// TestBrowser_runCmd_noCommand checks that runCmd reports ErrNoCommandFound instead of
+// running anything when no browser command resolves.
+func TestBrowser_runCmd_noCommand(t *testing.T) {
+	t.Parallel()
+
+	b := &Browser{lookPath: func(string) (string, error) { return "", errors.New("not found") }}
+	if err := b.runCmd(t.Context(), deviceURL); !errors.Is(err, ErrNoCommandFound) {
+		t.Errorf("runCmd() = %v, want ErrNoCommandFound", err)
 	}
 }
 

--- a/ghtkn/browser/browser_internal_test.go
+++ b/ghtkn/browser/browser_internal_test.go
@@ -4,8 +4,24 @@ package browser
 
 import (
 	"errors"
+	"os"
 	"testing"
 )
+
+// TestBrowserCmd checks that opening a browser can't write to the standard output of
+// the process opening it, which carries the access token in 'ghtkn get' and git's
+// credential protocol in 'ghtkn git-credential'.
+func TestBrowserCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := browserCmd(t.Context(), "xdg-open", "https://github.com/login/device")
+	if cmd.Stdout != os.Stderr {
+		t.Errorf("Stdout = %v, want os.Stderr", cmd.Stdout)
+	}
+	if cmd.Stderr != os.Stderr {
+		t.Errorf("Stderr = %v, want os.Stderr", cmd.Stderr)
+	}
+}
 
 func TestBrowser_Available(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Why

The command that opens the browser during the device flow inherited the SDK caller's stdout (`ghtkn/browser/exec.go` sets `cmd.Stdout = os.Stdout`).

That stdout is not free real estate. It carries data the caller parses:

- `ghtkn get` writes the access token to it, so `GH_TOKEN=$(ghtkn get)` captures anything the browser command printed along with the token.
- `ghtkn git-credential` speaks git's credential protocol on it, so extra output makes git fail to parse the credential.

In both cases a single stray line corrupts the credential, and the failure looks like a bad token rather than like browser output — the kind of thing nobody would think to look for.

macOS is unaffected in practice: `open` writes its diagnostics to stderr (verified for an unknown URL scheme, a missing file, and a missing application). Linux is the real exposure. `cmds()` there is `xdg-open`, `x-www-browser`, `www-browser`, and Debian's `www-browser` alternative resolves to w3m, lynx or elinks on some hosts. A text browser renders the whole page to stdout, so this is not a stray line but a screenful.

`Available()` only checks whether one of those names is on PATH, so on a host with w3m installed and no GUI the SDK considers a browser available and runs it.

## What

`Browser` gains a `stdout io.Writer` field, following the nil-defaults pattern already used by `lookPath`, and `runCmd` builds the command through a new `browserCmd` method that honors it:

```go
func (b *Browser) browserCmd(ctx context.Context, name, url string) *exec.Cmd {
	cmd := command(ctx, name, url)
	cmd.Stdout = b.stdoutWriter()
	return cmd
}
```

The default is `os.Stderr`. Nothing a browser command writes to stdout is meaningful, so nothing is lost: the output still reaches the terminal, just on the stream meant for it. A text browser also keeps working, since stderr is the terminal too.

The redirection lives in `browser.go` rather than in `exec.go`, which is a copy of `github.com/suzuki-shunsuke/go-exec` and is kept identical to it.

`runCmd` now runs the path `findCmd` resolved instead of the bare name. That is what the lookup was for, and it is what lets a test drive `runCmd` through the injected `lookPath` without touching PATH or launching a real browser.

### Public API

This adds one method, `(*Browser).SetStdout(io.Writer)`. It is additive; `Open` and `Available` are untouched and the zero value keeps the previous behavior.

The SDK is otherwise injectable throughout — `Client.SetBrowser`, `Client.SetOnetimeCodeUI`, `ui.stderr io.Writer` — and hardcoding a package-level global here would have made the browser package the odd one out. A process embedding the SDK can now send the browser command's output to a log or `io.Discard` instead of its own standard error:

```go
db := &ghtkn.DefaultBrowser{}
db.SetStdout(io.Discard)
client.SetBrowser(db)
```

## Testing

`go test ./... -race -covermode=atomic` passes, `golangci-lint run` reports 0 issues, `gofumpt` is clean, and `GOOS=windows go vet ./...` passes. Windows doesn't reach this path at all — `openB` there calls `ShellExecute` and `cmds()` returns nil.

`TestBrowser_runCmd_stdout` drives `runCmd` rather than `browserCmd`, pointing `lookPath` at `echo` and asserting the command's output reaches an injected writer. Testing `browserCmd` alone would have restated its one-line body and stayed green even if `runCmd` stopped calling it, which is exactly the regression worth pinning.

Both directions were checked by mutation. Reverting `runCmd` to build the command directly:

```
--- FAIL: TestBrowser_runCmd_stdout
    browser command stdout = "", want "https://github.com/login/device"; it must not reach os.Stdout
```

Dropping the assignment in `browserCmd`:

```
--- FAIL: TestBrowser_browserCmd_defaultStdout
    Stdout = &{0x5a04866900c0}, want os.Stderr
--- FAIL: TestBrowser_runCmd_stdout
    browser command stdout = "", want "https://github.com/login/device"
```

In both failures the leaked URL is visible on the test process's own stdout, which is the bug reproducing.

`TestBrowser_browserCmd_defaultStdout` covers the `os.Stderr` default that the `runCmd` test can't observe, and `TestBrowser_runCmd_noCommand` covers the `ErrNoCommandFound` path. Package coverage goes from 64.5% to 86.1%.

The assertion on `cmd.Stderr` was dropped: it tested `command` in `exec.go`, the vendored upstream copy, from a test named for `browserCmd`.

The behavior was also verified end to end with a throwaway test that shadowed `open` and `xdg-open` on PATH with a script printing to both streams:

```
before:  stdout="NOISE_ON_STDOUT\n"  stderr="NOISE_ON_STDERR\n"
after:   stdout=""                   stderr="NOISE_ON_STDOUT\nNOISE_ON_STDERR\n"
```

That test isn't part of the diff: it manipulates `os.Stdout` and PATH process-wide, so it can't run in parallel and it is far more fragile than the behavior it pins.

## Follow-ups, not in this PR

- The browser command still inherits the caller's stdin (`exec.go` sets `cmd.Stdin = os.Stdin`). In git credential helper mode that stdin is the pipe git writes the credential request into — `ghtkn/internal/deviceflow/ui/device_ui.go` already documents that it is not a terminal there. A text browser reaching that pipe consumes git's protocol bytes, which is the same failure mode as this PR's, under the same precondition. `cmd.Stdin = nil` in `browserCmd` would close it.
- `Available()` reports true whenever one of the command names is on PATH, without checking for a GUI (`DISPLAY` / `WAYLAND_DISPLAY`). On a headless host with w3m installed, the SDK will still launch a text browser that takes over the terminal. Dropping `www-browser` from the candidates, or checking for a display, would address the cause rather than the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-launch handling to prevent command output from appearing in standard output.
  * Browser launch errors continue to be reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
