### PR TITLE
fix: stop the browser command from reading the caller's stdin

### DIFF
--- a/ghtkn/browser/browser.go
+++ b/ghtkn/browser/browser.go
@@ -112,10 +112,26 @@ func (b *Browser) runCmd(ctx context.Context, url string) error {
 // writer from stdoutWriter instead of the standard output of this process. See
 // SetStdout for why that output must not go to os.Stdout.
 //
+// Its standard input is nil, so the command reads from the null device rather than
+// from the standard input of this process. That input is not spare either: a git
+// credential helper built on this SDK is fed git's credential request on it, and
+// deviceflow's UI reads the user's Enter key from it. A browser command that reads a
+// byte of it takes that byte away from its owner, and the failure looks like a
+// truncated credential request rather than like the browser. A command that opens a
+// GUI browser never reads stdin, but on Linux the command can be a text browser,
+// since the www-browser alternative resolves to w3m or lynx on some hosts, and those
+// read stdin as keyboard input.
+//
+// A text browser therefore sees EOF and exits instead of taking over the terminal.
+// That is the intended outcome: the verification URL is already on stderr, so the
+// user can open it, whereas a text browser driven by a credential request is not a
+// state anyone can act on.
+//
 // The rest of the defaults, including stderr and the signal handling, come from
 // command, which is kept identical to its upstream copy.
 func (b *Browser) browserCmd(ctx context.Context, name, url string) *exec.Cmd {
 	cmd := command(ctx, name, url)
 	cmd.Stdout = b.stdoutWriter()
+	cmd.Stdin = nil
 	return cmd
 }

--- a/ghtkn/browser/browser_internal_test.go
+++ b/ghtkn/browser/browser_internal_test.go
@@ -5,13 +5,70 @@ package browser
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 const deviceURL = "https://github.com/login/device"
+
+// TestBrowser_runCmd_stdin checks that the command opening the browser can't read the
+// standard input of the process opening it, which carries git's credential request for
+// a git credential helper and the user's Enter key for deviceflow's UI.
+//
+// The check has to be behavioral rather than an assertion on cmd.Stdin, because
+// asserting the field would restate browserCmd's body. It therefore gives this process
+// a stdin holding a sentinel and uses a browser command that copies whatever stdin it
+// gets to stdout: reaching the sentinel is the bug, and it shows up in the output.
+//
+// It does not call t.Parallel, because os.Stdin is process-global. Go runs the body of
+// a serial test while every parallel test in the package is paused, so nothing else
+// observes the swap.
+func TestBrowser_runCmd_stdin(t *testing.T) {
+	// A script rather than cat itself: runCmd passes the URL as an argument, and cat
+	// would read that as a file name instead of reading stdin.
+	script := filepath.Join(t.TempDir(), "browser")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ncat\n"), 0o700); err != nil { //nolint:gosec // the script must be executable
+		t.Fatalf("write the stub browser command: %v", err)
+	}
+
+	// The writer is closed right after the sentinel so that a command reading this
+	// stdin sees EOF and exits, making the bug fail the test instead of hanging it.
+	const sentinel = "CREDENTIAL_REQUEST_FROM_THE_CALLER\n"
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create a pipe: %v", err)
+	}
+	if _, err := io.WriteString(w, sentinel); err != nil {
+		t.Fatalf("write the sentinel: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close the pipe writer: %v", err)
+	}
+
+	stdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = stdin
+		if err := r.Close(); err != nil {
+			t.Errorf("close the pipe reader: %v", err)
+		}
+	})
+
+	stdout := &bytes.Buffer{}
+	b := &Browser{lookPath: func(string) (string, error) { return script, nil }}
+	b.SetStdout(stdout)
+
+	if err := b.runCmd(t.Context(), deviceURL); err != nil {
+		t.Fatalf("runCmd() = %v, want nil", err)
+	}
+	if got := stdout.String(); got != "" {
+		t.Errorf("the browser command read %q from the standard input of this process, want it to read nothing", got)
+	}
+}
 
 // TestBrowser_runCmd_stdout checks that the command opening the browser can't write to
 // the standard output of the process opening it, which carries the access token for a


### PR DESCRIPTION
## Why

This is the follow-up flagged in #404. That PR stopped the browser command from writing to the caller's stdout; the same command still reads the caller's stdin.

`browserCmd` inherits `cmd.Stdin = os.Stdin` from `command` in `exec.go`. That input is not spare:

- A git credential helper built on this SDK is fed git's credential request on it. `ghtkn/internal/deviceflow/ui/device_ui.go` already documents this: "In case of Git Credential Helper stdin is not a terminal, so it exits immediately."
- deviceflow's UI reads the user's Enter key from it.

A byte the browser command consumes is a byte its owner never sees, and the failure looks like a truncated credential request rather than like the browser — the same class of thing nobody would think to look for.

The precondition is the one from #404. A command that opens a GUI browser never reads stdin, so macOS `open` and `xdg-open` are unaffected. Linux is the exposure: `cmds()` includes `www-browser`, Debian's alternative resolves to w3m, lynx or elinks on some hosts, and those read stdin as keyboard input. `Available()` only checks whether one of the names is on PATH, so on a headless host with w3m installed the SDK considers a browser available and runs it.

## What

`browserCmd` sets `cmd.Stdin = nil`, which points the command at the null device:

```go
func (b *Browser) browserCmd(ctx context.Context, name, url string) *exec.Cmd {
	cmd := command(ctx, name, url)
	cmd.Stdout = b.stdoutWriter()
	cmd.Stdin = nil
	return cmd
}
```

As in #404, this lives in `browser.go` rather than in `exec.go`, which is a copy of `github.com/suzuki-shunsuke/go-exec` and is kept identical to it.

No public API change.

### Behavior change worth calling out

A text browser now sees EOF and exits instead of taking over the terminal. That is the intended outcome rather than a side effect, but it is a change for anyone who was completing the device flow inside w3m: the verification URL is already printed to stderr for the user to open, whereas a text browser being driven by a credential request is not a state anyone can act on.

Unlike stdout, this is not made configurable. There is no writer to choose between — the only sensible input for a browser command is none — and a `SetStdin` would exist only to let a caller reintroduce the bug.

## Testing

`go test ./... -race -covermode=atomic` passes, `golangci-lint run` reports 0 issues, `gofumpt` is clean, and `GOOS=windows go vet ./...` passes. Windows doesn't reach this path at all — `openB` there calls `ShellExecute` and `cmds()` returns nil.

`TestBrowser_runCmd_stdin` checks the behavior rather than the field. Asserting on `cmd.Stdin` would restate `browserCmd`'s body and stay green if `runCmd` stopped calling it, which is the trap #404 fell into. Instead the test gives this process a stdin holding a sentinel and uses a browser command that copies whatever stdin it gets to stdout, so reaching the sentinel is the bug and it shows up in the captured output.

Removing `cmd.Stdin = nil` fails it, with the defect visible in the message:

```
--- FAIL: TestBrowser_runCmd_stdin
    the browser command read "CREDENTIAL_REQUEST_FROM_THE_CALLER\n" from the standard input
    of this process, want it to read nothing
```

Two details the test needs. The stub browser command is a script running `cat` rather than `cat` itself, because `runCmd` passes the URL as an argument and `cat` would read that as a file name instead of reading stdin. The pipe writer is closed right after the sentinel so that a command reading this stdin sees EOF and exits, which makes the bug fail the test instead of hanging it.

It is the one test in the package that does not call `t.Parallel`, because `os.Stdin` is process-global. Go runs the body of a serial test while every parallel test in the package is paused, so nothing else observes the swap.

Package coverage goes from 86.1% to 86.5%.

## Follow-ups, not in this PR

- `Available()` reports true whenever one of the command names is on PATH, without checking for a GUI (`DISPLAY` / `WAYLAND_DISPLAY`). On a headless host with w3m installed, the SDK still launches a text browser. With stdout and stdin both handled, the remaining damage is bounded, but dropping `www-browser` from the candidates or checking for a display would address the cause rather than the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
