### PR TITLE
feat: add apps[].git_owners to select one app for several repository owners

### DIFF
--- a/ghtkn/config/app.go
+++ b/ghtkn/config/app.go
@@ -1,8 +1,10 @@
 package config
 
+import "slices"
+
 // ResolveApp resolves the app ghtkn should use from cfg by applying the selection
 // priority:
-//  1. If owner is non-empty and matches an app's GitOwner, that app.
+//  1. If owner is non-empty and matches an app's GitOwner or one of its GitOwners, that app.
 //  2. If key is empty (regardless of whether owner matched), the first app in the list
 //     (the default app).
 //  3. Otherwise the app whose Name equals key (nil when none matches).
@@ -16,7 +18,7 @@ func ResolveApp(cfg *Config, key, owner string) *App {
 	}
 	if owner != "" {
 		for _, a := range cfg.Apps {
-			if a.GitOwner == owner {
+			if slices.Contains(a.gitOwners(), owner) {
 				return a
 			}
 		}

--- a/ghtkn/config/app_test.go
+++ b/ghtkn/config/app_test.go
@@ -12,6 +12,7 @@ func TestResolveApp(t *testing.T) {
 	cfg := &config.Config{Apps: []*config.App{
 		{Name: "first", ClientID: "Iv1.first", GitOwner: "owner-a"},
 		{Name: "second", ClientID: "Iv1.second", GitOwner: "owner-b"},
+		{Name: "third", ClientID: "Iv1.third", GitOwners: []string{"owner-c", "owner-d"}},
 	}}
 
 	tests := []struct {
@@ -22,6 +23,8 @@ func TestResolveApp(t *testing.T) {
 		want  string // expected app Name, or "" when the result is nil
 	}{
 		{name: "owner match wins over key", cfg: cfg, key: "first", owner: "owner-b", want: "second"},
+		{name: "git_owners first element match", cfg: cfg, key: "", owner: "owner-c", want: "third"},
+		{name: "git_owners later element match", cfg: cfg, key: "first", owner: "owner-d", want: "third"},
 		{name: "key match", cfg: cfg, key: "second", owner: "", want: "second"},
 		{name: "key not found is nil", cfg: cfg, key: "missing", owner: "", want: ""},
 		{name: "both empty is the first app", cfg: cfg, key: "", owner: "", want: "first"},

--- a/ghtkn/config/config.go
+++ b/ghtkn/config/config.go
@@ -60,8 +60,8 @@ type Backend struct {
 
 // Validate checks if the Config is valid.
 // It ensures the config is not nil and contains at least one app.
-// It also validates each app in the configuration, and that name, client_id, and
-// git_owner are each unique across the apps.
+// It also validates each app in the configuration, and that name, client_id, and each
+// repository owner (git_owner and the git_owners elements) are unique across the apps.
 func (c *Config) Validate() error {
 	if c == nil {
 		return errors.New("config is required")
@@ -70,7 +70,9 @@ func (c *Config) Validate() error {
 		return errors.New("apps is required")
 	}
 	names := map[string]struct{}{}
-	owners := map[string]struct{}{}
+	// owners maps a repository owner to the app that declared it, so a duplicate can
+	// name the other app instead of only the owner.
+	owners := map[string]string{}
 	// clientIDs maps a client ID to the app that declared it, so a duplicate can name
 	// the other app instead of only the ID.
 	clientIDs := map[string]string{}
@@ -91,16 +93,18 @@ func (c *Config) Validate() error {
 			return fmt.Errorf(
 				"app client_id must be unique: %q and %q share the client id %s. "+
 					"They would share one access token, so revoking or minting for one would silently do it for the other. "+
-					"Keep a single app for that client id; to use it for several repository owners, "+
-					"select it with the GHTKN_APP or GHTKN_GIT_APP environment variable instead of a second git_owner entry",
+					"Keep a single app for that client id; to select it for several repository owners, "+
+					"list them in that app's git_owners instead of adding a second entry",
 				other, app.Name, app.ClientID)
 		}
 		clientIDs[app.ClientID] = app.Name
-		if app.GitOwner != "" {
-			if _, ok := owners[app.GitOwner]; ok {
-				return fmt.Errorf("app git_owner must be unique: %s", app.GitOwner)
+		for _, owner := range app.gitOwners() {
+			if other, ok := owners[owner]; ok {
+				return fmt.Errorf(
+					"a repository owner must be unique across apps: %q and %q both declare the owner %s",
+					other, app.Name, owner)
 			}
-			owners[app.GitOwner] = struct{}{}
+			owners[owner] = app.Name
 		}
 	}
 	return nil
@@ -112,10 +116,16 @@ type App struct {
 	Name     string `json:"name"`
 	ClientID string `json:"client_id" yaml:"client_id"`
 	GitOwner string `json:"git_owner,omitempty" yaml:"git_owner"`
+	// GitOwners is git_owner for an app shared by several repository owners, such as an
+	// Enterprise GitHub App installed on several organizations. The app can't be
+	// repeated once per owner because client_id must be unique across apps, so the
+	// owners are listed here instead. GitOwner and GitOwners are mutually exclusive.
+	GitOwners []string `json:"git_owners,omitempty" yaml:"git_owners"`
 }
 
 // Validate checks if the App configuration is valid.
-// It ensures both Name and ClientID fields are present.
+// It ensures both Name and ClientID fields are present, and that git_owner and
+// git_owners are not both set and that git_owners holds no empty or duplicate owner.
 func (app *App) Validate() error {
 	if app.Name == "" {
 		return errors.New("name is required")
@@ -123,5 +133,28 @@ func (app *App) Validate() error {
 	if app.ClientID == "" {
 		return errors.New("client_id is required")
 	}
+	if app.GitOwner != "" && len(app.GitOwners) > 0 {
+		return errors.New("git_owner and git_owners are mutually exclusive: set only one of them")
+	}
+	owners := make(map[string]struct{}, len(app.GitOwners))
+	for _, owner := range app.GitOwners {
+		if owner == "" {
+			return errors.New("git_owners must not contain an empty string")
+		}
+		if _, ok := owners[owner]; ok {
+			return fmt.Errorf("git_owners must not contain a duplicate: %s", owner)
+		}
+		owners[owner] = struct{}{}
+	}
 	return nil
+}
+
+// gitOwners returns the repository owners this app is selected for. git_owner and
+// git_owners are mutually exclusive (App.Validate rejects setting both), so this
+// returns whichever one is set.
+func (app *App) gitOwners() []string {
+	if app.GitOwner != "" {
+		return []string{app.GitOwner}
+	}
+	return app.GitOwners
 }

--- a/ghtkn/config/config_test.go
+++ b/ghtkn/config/config_test.go
@@ -153,6 +153,62 @@ func TestConfig_Validate(t *testing.T) { //nolint:funlen
 			},
 			wantErr: false,
 		},
+		{
+			// The owner is declared by git_owner in one app and by git_owners in the
+			// other, so the uniqueness check must span both fields.
+			name: "duplicate git owners across git_owner and git_owners",
+			config: &config.Config{
+				Apps: []*config.App{
+					{
+						Name:     "app1",
+						ClientID: "xxx",
+						GitOwner: "same-owner",
+					},
+					{
+						Name:      "app2",
+						ClientID:  "yyy",
+						GitOwners: []string{"owner2", "same-owner"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate git owners across git_owners",
+			config: &config.Config{
+				Apps: []*config.App{
+					{
+						Name:      "app1",
+						ClientID:  "xxx",
+						GitOwners: []string{"owner1", "same-owner"},
+					},
+					{
+						Name:      "app2",
+						ClientID:  "yyy",
+						GitOwners: []string{"same-owner", "owner2"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid config with git_owners",
+			config: &config.Config{
+				Apps: []*config.App{
+					{
+						Name:      "enterprise",
+						ClientID:  "xxx",
+						GitOwners: []string{"owner1", "owner2"},
+					},
+					{
+						Name:     "app2",
+						ClientID: "yyy",
+						GitOwner: "owner3",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -204,6 +260,43 @@ func TestApp_Validate(t *testing.T) {
 			app: &config.App{
 				Name:     "",
 				ClientID: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid app with git_owners",
+			app: &config.App{
+				Name:      "test-app",
+				ClientID:  "xxx",
+				GitOwners: []string{"owner1", "owner2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "git_owner and git_owners are mutually exclusive",
+			app: &config.App{
+				Name:      "test-app",
+				ClientID:  "xxx",
+				GitOwner:  "owner1",
+				GitOwners: []string{"owner2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty git owner in git_owners",
+			app: &config.App{
+				Name:      "test-app",
+				ClientID:  "xxx",
+				GitOwners: []string{"owner1", ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate git owners in git_owners",
+			app: &config.App{
+				Name:      "test-app",
+				ClientID:  "xxx",
+				GitOwners: []string{"owner1", "owner1"},
 			},
 			wantErr: true,
 		},

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -13,6 +13,12 @@
         },
         "git_owner": {
           "type": "string"
+        },
+        "git_owners": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

## Why

A GitHub App owned by an enterprise can be installed on several organizations, but an app entry can be bound to only one repository owner through `git_owner`, so the Git credential helper can pick that app for only one of them.

Repeating the app once per owner is not a way out: `client_id` must be unique across apps, and `Config.Validate` rejects a second entry that shares one, because the two entries would be two names for a single stored access token.

The remaining alternative the error message and the docs suggest today, `GHTKN_APP` / `GHTKN_GIT_APP`, can't replace the credential helper's path based selection either: that selection is what picks an app per repository owner in the first place.

## What

`apps[].git_owners` lists the repository owners of such a shared app.

```yaml
apps:
  - name: my-company
    client_id: xxx
    git_owners:
      - my-company
      - my-company-sandbox
```

- `git_owner` keeps working and is not deprecated. `git_owner` and `git_owners` are mutually exclusive within an app.
- `git_owners` must hold no empty string and no duplicate.
- A repository owner must be unique across apps whether it comes from `git_owner` or from `git_owners`, so the uniqueness check now spans both fields and reports the two apps that collide, as the `client_id` check already does.
- `git_owner` was not turned into a field that also accepts an array. `json-schema/ghtkn.json` is generated from these structs in the ghtkn repository, so a union type would need a custom unmarshaler plus a hand written schema; two fields keep both generated and simple.

`ResolveApp` matches `owner` against `git_owner` and every `git_owners` element. Owner comparison stays case sensitive, as before.

`(*App).gitOwners()` normalizes the two fields into one owner list, so `Config.Validate` and `ResolveApp` both read owners from a single place. It is unexported: nothing outside the package needs it.

## Notes

- The JSON Schema in this repository is not generated by any script here and had already drifted from the one in the ghtkn repository (it is missing `clipboard`). This adds `git_owners` to it and leaves the existing drift alone.
- The ghtkn repository needs a follow-up: bump this module, regenerate `json-schema/ghtkn.json`, and update the documentation and the `git-credential` help text.

## Tests

`TestApp_Validate` covers the per app rules (mutual exclusion, empty element, duplicate element), `TestConfig_Validate` covers the cross app uniqueness including a `git_owner` colliding with another app's `git_owners`, and `TestResolveApp` covers selection by a `git_owners` element. The `config` package stays at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apps can now be configured with multiple repository owners.
  * App resolution recognizes any configured owner.
  * Configuration schema supports the new `git_owners` setting.

* **Bug Fixes**
  * Added validation to prevent empty, duplicate, or conflicting owner configurations.
  * Improved detection of duplicate owners across apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->